### PR TITLE
Mdx util

### DIFF
--- a/packages/gatsby-mdx/gatsby-node.js
+++ b/packages/gatsby-mdx/gatsby-node.js
@@ -1,8 +1,8 @@
 const crypto = require("crypto");
 const path = require("path");
-const mdx = require("@mdx-js/mdx");
-const matter = require("gray-matter");
+const grayMatter = require("gray-matter");
 const escapeStringRegexp = require('escape-string-regexp');
+const mdx = require("./utils/mdx");
 
 const defaultExtensions = [".mdx"]
 
@@ -21,7 +21,7 @@ exports.onCreateNode = async function onCreateNode(
   }
 
   const nodeContent = await loadNodeContent(node);
-  const { content, data } = matter(nodeContent);
+  const { content, data } = grayMatter(nodeContent);
 
   const mdxNode = {
     id: createNodeId(`${node.id} >>> Mdx`),
@@ -93,7 +93,7 @@ exports.resolvableExtensions = (data, pluginOptions) => (
   pluginOptions.extensions || defaultExtensions
 );
 
-exports.preprocessSource = function preprocessSource(
+exports.preprocessSource = async function preprocessSource(
   { filename, contents },
   pluginOptions
 ) {
@@ -101,7 +101,7 @@ exports.preprocessSource = function preprocessSource(
   const ext = path.extname(filename);
 
   if (extensions.includes(ext)) {
-    const code = mdx.sync(contents /*, pluginOptions*/);
+    const code = await mdx(contents, pluginOptions);
     return code;
   }
   return null;

--- a/packages/gatsby-mdx/mdx-loader.js
+++ b/packages/gatsby-mdx/mdx-loader.js
@@ -1,30 +1,22 @@
 const { getOptions } = require("loader-utils");
-const mdx = require("@mdx-js/mdx");
-const grayMatter = require("gray-matter");
+const mdx = require('./utils/mdx')
 
 const hasDefaultExport = str => /\nexport default/.test(str);
 
-module.exports = async function(content) {
+module.exports = async function(source) {
   const callback = this.async();
   const options = getOptions(this);
 
-  const matter = grayMatter(content);
+  let code = await mdx(source, options);
 
-  let newContent = `export const _frontmatter = ${JSON.stringify(matter.data)};
-
-${matter.content}
-  `;
-
-  if (!hasDefaultExport(newContent) && !!options.defaultLayout) {
-    newContent = `import DefaultLayout from "${options.defaultLayout}"
+  if (!hasDefaultExport(code) && !!options.defaultLayout) {
+    code = `import DefaultLayout from "${options.defaultLayout}"
 
 
 export default DefaultLayout
 
-${newContent}`;
+${code}`;
   }
-
-  const result = await mdx(newContent, options || {});
 
   return callback(
     null,
@@ -32,7 +24,7 @@ ${newContent}`;
 import { MDXTag } from '@mdx-js/tag'
 
 
-${result}
+${code}
   `
   );
 };

--- a/packages/gatsby-mdx/utils/mdx.js
+++ b/packages/gatsby-mdx/utils/mdx.js
@@ -1,0 +1,20 @@
+const mdx = require("@mdx-js/mdx");
+const grayMatter = require("gray-matter");
+/**
+ * Converts MDX to JSX, including converting classic frontmatter to an
+ * exported variable.
+ * 
+ * @param  {String} source  MDX source
+ * @param  {Object} options options for mdx library
+ * @return {String}         JSX source
+ */
+module.exports = async function mdxToJsx(source, options) {
+  const { data, content } = grayMatter(source);
+
+  let code = await mdx(content, options || {});
+
+  return `${code}
+
+export const _frontmatter = ${JSON.stringify(data)};
+`;
+}


### PR DESCRIPTION
Added an `mdx` util that wraps the MDX -> JSX library to also convert the frontmatter, so that we always get out babel-ready code.