### PR TITLE
Change 'babel-core' import to '@babel/core'

### DIFF
--- a/packages/gatsby-mdx/utils/extract-exports.js
+++ b/packages/gatsby-mdx/utils/extract-exports.js
@@ -1,4 +1,4 @@
-const babel = require("babel-core");
+const babel = require("@babel/core");
 const babelReact = require("@babel/preset-react");
 const objRestSpread = require("@babel/plugin-proposal-object-rest-spread");
 const mdx = require("./mdx");


### PR DESCRIPTION
The other imports refer to the 7.x major version; `gatsby-mdx` does not work unless I make this change.