### PR TITLE
docs: fix absolute path for node in create pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ exports.createPages = ({ graphql, actions }) => {
           createPage({
             path: `/non-page/${node.fileNode.name}`,
             component: node.fileAbsolutePath, //blogPost,
-            context: { absPath: node.absolutePath }
+            context: { absPath: node.fileAbsolutePath }
           });
         });
       })


### PR DESCRIPTION
I don't think there is a field called `node.absolutePath`, so changing it to `node.fileAbsolutePath` as is used above.