### PR TITLE
style: start styling docs site

### DIFF
--- a/examples/docs/content/docs/api-reference.mdx
+++ b/examples/docs/content/docs/api-reference.mdx
@@ -1,6 +1,3 @@
-
-export default ({children, ...props}) => console.log(props) || <div>{children}</div>
-
 # API Reference
 
 ## Plugin Options

--- a/examples/docs/package.json
+++ b/examples/docs/package.json
@@ -9,6 +9,7 @@
     "@mdx-js/mdx": "^0.15.0-2",
     "emotion": "^9.1.3",
     "emotion-server": "^9.1.3",
+    "emotion-theming": "^9.2.6",
     "gatsby": "next",
     "gatsby-mdx": "*",
     "gatsby-plugin-emotion": "next",
@@ -18,7 +19,8 @@
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-emotion": "^9.1.3",
-    "react-helmet": "^5.2.0"
+    "react-helmet": "^5.2.0",
+    "system-components": "^3.0.0"
   },
   "license": "MIT",
   "main": "n/a",

--- a/examples/docs/src/components.js
+++ b/examples/docs/src/components.js
@@ -1,0 +1,88 @@
+/* eslint-disable react/display-name */
+
+import * as React from "react";
+import system from "system-components/emotion";
+
+export const Pre = system(
+  {
+    is: "pre",
+    fontSize: 1,
+    fontFamily: "mono",
+    m: 0
+  },
+  {
+    overflow: "auto"
+  },
+  "fontFamily",
+  "space",
+  "color"
+);
+
+export const Code = system(
+  {
+    is: "code",
+    fontSize: 1,
+    fontFamily: "mono"
+  },
+  "fontFamily",
+  "space",
+  "color"
+);
+
+export const Heading = system(
+  {
+    is: "h2",
+    fontSize: 5,
+    fontWeight: "bold",
+    lineHeight: 1.25,
+    mt: 4,
+    mb: 3
+  },
+  "fontFamily",
+  "color",
+  "textAlign"
+);
+
+Heading.displayName = "Heading";
+
+export const Container = system(
+  {
+    is: "div",
+    px: 3,
+    mx: "auto",
+    maxWidth: 1024
+  },
+  "maxWidth"
+);
+
+export const Text = system(
+  {
+    m: 0
+  },
+  "space",
+  "color",
+  "fontFamily",
+  "fontSize",
+  "fontWeight",
+  "textAlign",
+  "lineHeight"
+);
+
+export const components = {
+  h1: props => <Heading {...props} is="h1" fontSize={[5, 6]} />,
+  h2: props => <Heading {...props} is="h2" fontSize={[4, 5]} />,
+  h3: props => <Heading {...props} is="h3" fontSize={3} />,
+  h4: props => <Heading {...props} is="h4" fontSize={2} />,
+  h5: props => <Heading {...props} is="h5" fontSize={1} />,
+  h6: props => <Heading {...props} is="h6" fontSize={0} />,
+  p: props => <Text {...props} is="p" lineHeight={1.625} mt={3} mb={4} />,
+  pre: Pre,
+  code: Code,
+  inlineCode: props => <Code {...props} bg="lightgray" p={1} />
+  // TODO add `a`
+  // TODO add `img`
+  // TODO add `blockquote`
+  // TODO add `ul`
+  // TODO add `li`
+  // TODO add `table`
+};

--- a/examples/docs/src/docs-layout.js
+++ b/examples/docs/src/docs-layout.js
@@ -6,11 +6,19 @@ import MDXRenderer from "gatsby-mdx/mdx-renderer";
 import { MDXProvider } from "@mdx-js/tag";
 
 import Highlight, { defaultProps } from "prism-react-renderer";
+import { ThemeProvider } from "emotion-theming";
+import { Container, components, Pre } from "./components";
+
+const theme = {
+  fonts: {
+    mono: '"SF Mono", "Roboto Mono", Menlo, monospace'
+  }
+};
 
 const CodeBlock = ({ children: exampleCode }) => (
   <Highlight {...defaultProps} code={exampleCode} language="jsx">
     {({ className, style, tokens, getLineProps, getTokenProps }) => (
-      <pre className={className} style={style}>
+      <Pre className={className} style={style} p={3}>
         {tokens.map((line, i) => (
           <div {...getLineProps({ line, key: i })}>
             {line.map((token, key) => (
@@ -18,7 +26,7 @@ const CodeBlock = ({ children: exampleCode }) => (
             ))}
           </div>
         ))}
-      </pre>
+      </Pre>
     )}
   </Highlight>
 );
@@ -28,19 +36,21 @@ export default class MDXRuntimeTest extends Component {
     const { children, data, tableOfContents } = this.props;
 
     return (
-      <MDXProvider
-        components={{
-          code: CodeBlock
-        }}
-      >
-        <div>
-          <h1>Uses MDXRenderer</h1>
-          <div>{children}</div>
-          <MDXRenderer tableOfContents={tableOfContents}>
-            {data.mdx.code.body}
-          </MDXRenderer>
-        </div>
-      </MDXProvider>
+      <ThemeProvider theme={theme}>
+        <MDXProvider
+          components={{
+            ...components,
+            code: CodeBlock
+          }}
+        >
+          <Container>
+            {children}
+            <MDXRenderer tableOfContents={tableOfContents}>
+              {data.mdx.code.body}
+            </MDXRenderer>
+          </Container>
+        </MDXProvider>
+      </ThemeProvider>
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4972,6 +4972,12 @@ emotion-server@^9.1.3:
   dependencies:
     create-emotion-server "^9.2.6"
 
+emotion-theming@^9.2.6:
+  version "9.2.6"
+  resolved "https://registry.yarnpkg.com/emotion-theming/-/emotion-theming-9.2.6.tgz#ca69b94e28f66a5d9ca1e259633246beaa24afbc"
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+
 emotion@^9.1.3:
   version "9.2.6"
   resolved "https://registry.yarnpkg.com/emotion/-/emotion-9.2.6.tgz#48517515e769bca6d8f7ff18425a7f133b010f22"
@@ -7318,7 +7324,7 @@ hoek@5.x.x:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.4.tgz#0f7fa270a1cafeb364a4b2ddfaa33f864e4157da"
 
-hoist-non-react-statics@^2.5.0, hoist-non-react-statics@^2.5.5:
+hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0, hoist-non-react-statics@^2.5.5:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
@@ -14065,6 +14071,12 @@ symbol-observable@^1.0.3, symbol-observable@^1.1.0:
 symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
+
+system-components@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/system-components/-/system-components-3.0.0.tgz#073e7c6712012c3c17375bae3ae986cb81866347"
+  dependencies:
+    styled-system "^3.0.1"
 
 table@4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Relates to #66 

This branch is a start at styling the MDX doc layout.

![image](https://user-images.githubusercontent.com/2344137/44706401-5254d200-aa56-11e8-8df3-842027487482.png)

I grabbed snippets from and learned about building out design system components from the Rebass codebase (especially [`@rebass/markdown`](https://github.com/jxnblk/rebass/blob/master/markdown/index.js)), so it looks a lot like Rebass but isn't technically right now. Open to talking through what the site should look like here or in another issue, but it helps me move forward when I can visualize something and go from there, and also it's a little bit more fun to write docs when the output is a little bit prettier. 😄 