### PR TITLE
Extensions docs and notification component

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,60 +298,9 @@ export default class MyPageLayout extends Component {
 }
 ```
 
----
+# Extensions
 
-# Experimental
-
-Experimental things could be volatile. Use at your own risk.
-
-## MDX Deck
-
-To embed mdx-deck presentations in your gatsby site, add mdx deck to
-your dependencies (in addition to the gatsby-mdx and it's
-dependencies).
-
-```shell
-npm install mdx-deck
-```
-
-Add the relevant config to your `gatsby-config.js`. In this example,
-we use set the required `decks` key in the gatsby-mdx plugin config to
-point to our folder of slide decks and the filesystem source to point
-to our decks folder. We also set a `defaultLayout` that wraps every
-individual slide.
-
-```javascript
-const path = require("path");
-
-module.exports = {
-  siteMetadata: {
-    title: `Gatsby MDX Kitchen Sink`
-  },
-  plugins: [
-    `gatsby-plugin-emotion`,
-    `gatsby-plugin-react-helmet`,
-    {
-      resolve: `gatsby-mdx`,
-      options: {
-        extensions: [".mdx", ".md"],
-        decks: [path.resolve("./decks")],
-        defaultLayouts: {
-          default: require.resolve("./src/components/default-page-layout.js"),
-          slides: require.resolve("./src/components/default-slide-layout.js")
-        }
-      }
-    },
-    {
-      resolve: "gatsby-source-filesystem",
-      options: {
-        name: "slides",
-        path: `${__dirname}/decks/`
-      }
-    },
-    `gatsby-plugin-offline`
-  ]
-};
-```
+- [MDX Deck](examples/docs/content/docs/extensions/mdx-deck.mdx)
 
 # Contributing
 

--- a/examples/docs/content/docs/extensions/mdx-deck.mdx
+++ b/examples/docs/content/docs/extensions/mdx-deck.mdx
@@ -1,0 +1,56 @@
+import Notification from '../../../src/components/notification.js';
+import {Heading} from '../../../src/components';
+
+# MDX Deck
+
+<Notification type="warning">
+  <Heading is="h4" mt={0} fontSize={2}>Experimental</Heading>
+  <p>Experimental things could be volatile. Use at your own risk.</p>
+</Notification>
+
+To embed mdx-deck presentations in your gatsby site, add mdx deck to
+your dependencies (in addition to the gatsby-mdx and it's
+dependencies).
+
+```shell
+npm install mdx-deck
+```
+
+Add the relevant config to your `gatsby-config.js`. In this example,
+we use set the required `decks` key in the gatsby-mdx plugin config to
+point to our folder of slide decks and the filesystem source to point
+to our decks folder. We also set a `defaultLayout` that wraps every
+individual slide.
+
+```javascript
+const path = require("path");
+
+module.exports = {
+  siteMetadata: {
+    title: `Gatsby MDX Kitchen Sink`
+  },
+  plugins: [
+    `gatsby-plugin-emotion`,
+    `gatsby-plugin-react-helmet`,
+    {
+      resolve: `gatsby-mdx`,
+      options: {
+        extensions: [".mdx", ".md"],
+        decks: [path.resolve("./decks")],
+        defaultLayouts: {
+          default: require.resolve("./src/components/default-page-layout.js"),
+          slides: require.resolve("./src/components/default-slide-layout.js")
+        }
+      }
+    },
+    {
+      resolve: "gatsby-source-filesystem",
+      options: {
+        name: "slides",
+        path: `${__dirname}/decks/`
+      }
+    },
+    `gatsby-plugin-offline`
+  ]
+};
+```

--- a/examples/docs/src/components/notification.js
+++ b/examples/docs/src/components/notification.js
@@ -1,0 +1,30 @@
+// import React from 'react';
+import styled from "react-emotion";
+
+const notificationTypes = {
+  warning: {
+    dark: "goldenrod",
+    light: "papayawhip"
+  },
+  error: {
+    dark: "firebrick",
+    light: "rosybrown"
+  },
+  info: {
+    dark: "cadetblue",
+    light: "aliceblue"
+  }
+};
+
+const getColor = (type = "info", shade = "dark") =>
+  notificationTypes[type][shade];
+
+const Notification = styled("section")`
+  border: 1px solid ${props => getColor(props.type)};
+  color: ${props => getColor(props.type)};
+  background: ${props => getColor(props.type, "light")};
+  display: grid;
+  padding: 15px;
+`;
+
+export default Notification;


### PR DESCRIPTION
Moved the mdx-deck info from the README to the docs site.

Also created a quick notification component in order to display the 'experimental' status. This will need to be refactored to use the theme etc.