### PR TITLE
Await promises returned by gatsbyRemarkPlugins

### DIFF
--- a/packages/gatsby-mdx/utils/get-source-plugins-as-remark-plugins.js
+++ b/packages/gatsby-mdx/utils/get-source-plugins-as-remark-plugins.js
@@ -75,9 +75,9 @@ module.exports = async function getSourcePluginsAsRemarkPlugins({
     .map(plugin => {
       debug("userPlugins: contructing remark plugin for ", plugin);
       const requiredPlugin = require(plugin.resolve);
-      return () =>
+      const wrappedPlugin = () =>
         async function transformer(markdownAST) {
-          requiredPlugin(
+          await requiredPlugin(
             {
               markdownAST,
               markdownNode: mdxNode,
@@ -91,11 +91,13 @@ module.exports = async function getSourcePluginsAsRemarkPlugins({
           );
           return markdownAST;
         };
+
+      return [wrappedPlugin, {}];
     });
 
   if (pathPlugin) {
-    return [pathPlugin, ...userPlugins, htmlToJSXPlugin];
+    return [pathPlugin, ...userPlugins, [htmlToJSXPlugin, {}]];
   } else {
-    return [...userPlugins, htmlToJSXPlugin];
+    return [...userPlugins, [htmlToJSXPlugin, {}]];
   }
 };


### PR DESCRIPTION
This makes sure

1. Promises returned by gatsbyRemarkPlugins are awaited in the mdPlugin wrapper
2. `mdPlugins` are handed to mdx/remark/unified in the form `[plugin, {}]` rather than just `plugin`. Seems unified will only wait for promises with the former one.

With this change I was able to get a customized version of gatbsy-remark-images working (one that does not need the `markdownNode` param).