### PR TITLE
docs: add missing page-creator plugin link

### DIFF
--- a/examples/docs/content/docs/guides/writing-pages-in-mdx.mdx
+++ b/examples/docs/content/docs/guides/writing-pages-in-mdx.mdx
@@ -2,7 +2,7 @@
 
 After [installing](/docs/guides/getting-started) the plugin, MDX files
 written in `src/pages` will turn into pages. This happens because
-gatsby bundles a [page-creator plugin][page-creator-plugin] by
+gatsby bundles a [page-creator plugin][] by
 default. Pages are rendered at a URL that is constructed from the
 filesystem path inside `src/pages`. An MDX file at
 `src/pages/awesome.mdx` will result in a page being rendered at
@@ -26,3 +26,5 @@ export const pageQuery = graphl`
 
 TODO: show prop usage from query
 ```
+
+[page-creator plugin]: https://www.npmjs.com/package/gatsby-plugin-page-creator


### PR DESCRIPTION
Saw a missing link when reading through some docs today. Lemme know if that's the right URL we want to link to. 👍 