### PR TITLE
fix invalid code in docs

### DIFF
--- a/examples/docs/content/guides/programmatically-creating-pages.mdx
+++ b/examples/docs/content/guides/programmatically-creating-pages.mdx
@@ -67,7 +67,7 @@ exports.createPages = ({ graphql, actions }) => {
         // Create blog posts pages.
         result.data.allMdx.edges.forEach(({ node }) => {
           createPage({
-            path: `/${sourceInstanceName}/${node.parent.name}`,
+            path: `/${node.parent.sourceInstanceName}/${node.parent.name}`,
             component: componentWithMDXScope(
               path.resolve("./src/components/posts-page-layout.js"),
               node.code.scope


### PR DESCRIPTION
the code in docs is incomplete; if copied and pasted it gets a ` ReferenceError: sourceInstanceName is not defined` error