### PR TITLE
Add keywords to package.json, to be included in gatsbys plugin directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,13 @@
     "husky": "^0.14.3",
     "lint-staged": "^7.2.0",
     "prettier": "^1.13.7"
-  }
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "gatsby-transformer-plugin",
+    "mdx",
+    "markdown",
+    "remark",
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "gatsby-transformer-plugin",
     "mdx",
     "markdown",
-    "remark",
+    "remark"
   ]
 }


### PR DESCRIPTION
As requested in https://github.com/ChristopherBiscardi/gatsby-mdx/issues/135 I added some keywords as required by Gatsby's plugin directory to be discovered as well as tags used by other mdx packages as well..