### PR TITLE
fix typo in using-gatsby-remark-images.mdx

### DIFF
--- a/examples/docs/content/guides/using-gatsby-remark-images.mdx
+++ b/examples/docs/content/guides/using-gatsby-remark-images.mdx
@@ -7,7 +7,7 @@ To enable gatsby-remark-images, you first need to install the relevant
 image plugins:
 
 ```shell
-yarn add gatsby-sharp gatsby-remark-images
+yarn add gatsby-plugin-sharp gatsby-remark-images
 ```
 
 If you don't have `gatsby-source-filesystem` installed, also install that.


### PR DESCRIPTION
should read `gatsby-plugin-sharp` instead of `gatsby-sharp`