### PR TITLE
fix: Use platform agnostic paths

### DIFF
--- a/packages/gatsby-mdx/component-with-mdx-scope.js
+++ b/packages/gatsby-mdx/component-with-mdx-scope.js
@@ -4,6 +4,7 @@ const path = require("path");
 const babel = require("@babel/core");
 const syntaxObjRestSpread = require("@babel/plugin-syntax-object-rest-spread");
 const debug = require("debug")("gatsby-mdx:component-with-mdx-scope");
+const slash = require("slash");
 
 const BabelPluginPluckExports = require("babel-plugin-pluck-exports");
 
@@ -28,11 +29,8 @@ module.exports = function componentWithMDXScope(
 
   const scopeHashes = codeScopeAbsPaths.map(codeScopeAbsPath => {
     // get the preexisting hash for the scope file to use in the new wrapper filename
-    const scopePathSegments = codeScopeAbsPath.split("/");
-    const scopeHash = scopePathSegments[scopePathSegments.length - 1].slice(
-      0,
-      -3
-    );
+    const base = path.parse(codeScopeAbsPath).base;
+    const scopeHash = base.slice(0, -3);
     return scopeHash;
   });
 
@@ -44,10 +42,10 @@ import React from 'react';
 import { MDXScopeProvider } from 'gatsby-mdx/context';
 
 ${codeScopeAbsPaths
-    .map((scopePath, i) => `import __mdxScope_${i} from '${scopePath}';`)
+    .map((scopePath, i) => `import __mdxScope_${i} from '${slash(scopePath)}';`)
     .join("\n")}
 
-import OriginalWrapper from '${absWrapperPath}';
+import OriginalWrapper from '${slash(absWrapperPath)}';
 
 import { graphql } from 'gatsby';
 

--- a/packages/gatsby-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-mdx/loaders/mdx-loader.js
@@ -19,6 +19,7 @@ const getSourcePluginsAsRemarkPlugins = require("../utils/get-source-plugins-as-
 const withDefaultOptions = require("../utils/default-options");
 const createMDXNode = require("../utils/create-mdx-node");
 const { createFileNode } = require("../utils/create-fake-file-node");
+const slash = require("slash");
 
 const DEFAULT_OPTIONS = {
   footnotes: true,
@@ -129,7 +130,7 @@ module.exports = async function(content) {
     debug("inserting default layout", defaultLayout);
     const { content: contentWithoutFrontmatter } = grayMatter(content);
 
-    code = `import DefaultLayout from "${defaultLayout}"
+    code = `import DefaultLayout from "${slash(defaultLayout)}"
 
 
 export default DefaultLayout

--- a/packages/gatsby-mdx/package.json
+++ b/packages/gatsby-mdx/package.json
@@ -26,6 +26,7 @@
     "mdast-util-toc": "^2.0.1",
     "remark": "^9.0.0",
     "retext": "^5.0.0",
+    "slash": "^2.0.0",
     "strip-markdown": "^3.0.1",
     "underscore.string": "^3.3.4",
     "unist-util-map": "^1.0.4",


### PR DESCRIPTION
Addresses issue #149 where path separator is assumed to be non Windows