### PR TITLE
Adds missing dependency on `mime`

### DIFF
--- a/packages/gatsby-mdx/package.json
+++ b/packages/gatsby-mdx/package.json
@@ -24,6 +24,7 @@
     "lodash": "^4.17.10",
     "mdast-util-to-string": "^1.0.4",
     "mdast-util-toc": "^2.0.1",
+    "mime": "^2.3.1",
     "remark": "^9.0.0",
     "retext": "^5.0.0",
     "slash": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6072,6 +6072,30 @@ gatsby-link@^2.0.0-rc.4:
     prop-types "^15.6.1"
     ric "^1.3.0"
 
+gatsby-mdx@*:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/gatsby-mdx/-/gatsby-mdx-0.1.4.tgz#7155669e6539c319a989996403051b4df4c59b20"
+  dependencies:
+    "@babel/plugin-proposal-object-rest-spread" "^7.0.0-beta.54"
+    babel-plugin-pluck-exports "0.0.1"
+    babel-plugin-pluck-imports "0.0.1"
+    debug "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    fs-extra "^7.0.0"
+    gray-matter "^4.0.1"
+    htmltojsx "^0.3.0"
+    json5 "^1.0.1"
+    lodash "^4.17.10"
+    mdast-util-to-string "^1.0.4"
+    mdast-util-toc "^2.0.1"
+    remark "^9.0.0"
+    retext "^5.0.0"
+    strip-markdown "^3.0.1"
+    underscore.string "^3.3.4"
+    unist-util-map "^1.0.4"
+    unist-util-remove "^1.0.1"
+    unist-util-visit "^1.4.0"
+
 gatsby-plugin-emotion@2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-emotion/-/gatsby-plugin-emotion-2.0.5.tgz#e44d0ee58fc07bb49889a28ca51e0cb4690aeeb4"


### PR DESCRIPTION
As mentioned [here](https://yarnpkg.com/lang/en/docs/workspaces/#toc-limitations-caveats) this kind of issue can be hard to detect, since the package is installed in the Yarn Workspace by another package.

Fixes
```
success write out page data — 0.003 s
success write out redirect data — 0.000 s
success onPostBootstrap — 0.000 s

info bootstrap finished - 2.16 s

error UNHANDLED REJECTION

  TypeError: mime.getType is not a function

  - create-fake-file-node.js:42 exports.createFileNode
    [site]/[gatsby-mdx]/utils/create-fake-file-node.js:42:28

  - mdx-loader.js:102 Object.module.exports
    [site]/[gatsby-mdx]/loaders/mdx-loader.js:102:22

  - LoaderRunner.js:119 LOADER_EXECUTION
    [site]/[loader-runner]/lib/LoaderRunner.js:119:14

  - LoaderRunner.js:120 runSyncOrAsync
    [site]/[loader-runner]/lib/LoaderRunner.js:120:4

  - LoaderRunner.js:229 iterateNormalLoaders
    [site]/[loader-runner]/lib/LoaderRunner.js:229:2

  - LoaderRunner.js:202 Array.<anonymous>
    [site]/[loader-runner]/lib/LoaderRunner.js:202:4

  - CachedInputFileSystem.js:43 Storage.finished
    [site]/[enhanced-resolve]/lib/CachedInputFileSystem.js:43:16

  - CachedInputFileSystem.js:79 provider
    [site]/[enhanced-resolve]/lib/CachedInputFileSystem.js:79:9

  - graceful-fs.js:78
    [site]/[graceful-fs]/graceful-fs.js:78:16

  - read_file_context.js:53 FSReqWrap.readFileAfterClose [as oncomplete]
    internal/fs/read_file_context.js:53:3

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```