### PR TITLE
Fixed typo in example code

### DIFF
--- a/examples/docs/content/guides/writing-pages-in-mdx.mdx
+++ b/examples/docs/content/guides/writing-pages-in-mdx.mdx
@@ -18,7 +18,7 @@ in the same way you would for a .js page.
 ```mdx
 import { graphql } from 'gatsby';
 
-export const pageQuery = graphl`
+export const pageQuery = graphql`
   allSitePages {
     TODO: flesh this query out
   }


### PR DESCRIPTION
MDX usage example used `graphl` instead of `graphql` in example code.