### PR TITLE
Added `html` field on `Mdx` GraphQL type

### DIFF
--- a/packages/gatsby-mdx/gatsby/extend-node-type.js
+++ b/packages/gatsby-mdx/gatsby/extend-node-type.js
@@ -22,6 +22,7 @@ const path = require("path");
 const { MDX_SCOPES_LOCATION } = require("../constants");
 
 const debug = require("debug")("gatsby-mdx:extend-node-type");
+const renderHTML = require("../utils/render-html");
 const getTableOfContents = require("../utils/get-table-of-content");
 const defaultOptions = require("../utils/default-options");
 const genMDX = require("../utils/gen-mdx");
@@ -215,17 +216,9 @@ export default { ${scopeIdentifiers.join(", ")} }`;
           if (mdxNode.html) {
             return Promise.resolve(mdxNode.html);
           }
-          const ast = await getAST(mdxNode);
 
-          const textLikeNodes = [];
-          visit(ast, node => {
-            if (node.type === "text" || node.type === "inlineCode") {
-              textLikeNodes.push(node.value);
-            }
-            return;
-          });
-
-          return textLikeNodes.join(" ");
+          const { body } = await processMDX({ node: mdxNode });
+          return renderHTML(body);
         }
       },
       tableOfContents: {

--- a/packages/gatsby-mdx/gatsby/extend-node-type.js
+++ b/packages/gatsby-mdx/gatsby/extend-node-type.js
@@ -209,6 +209,25 @@ export default { ${scopeIdentifiers.join(", ")} }`;
           return headings;
         }
       },
+      html: {
+        type: GraphQLString,
+        async resolve(mdxNode) {
+          if (mdxNode.html) {
+            return Promise.resolve(mdxNode.html);
+          }
+          const ast = await getAST(mdxNode);
+
+          const textLikeNodes = [];
+          visit(ast, node => {
+            if (node.type === "text" || node.type === "inlineCode") {
+              textLikeNodes.push(node.value);
+            }
+            return;
+          });
+
+          return textLikeNodes.join(" ");
+        }
+      },
       tableOfContents: {
         type: GraphQLJSON,
         args: {

--- a/packages/gatsby-mdx/mdx-renderer.js
+++ b/packages/gatsby-mdx/mdx-renderer.js
@@ -1,7 +1,7 @@
-import { withMDXComponents } from "@mdx-js/tag/dist/mdx-provider";
-import { withMDXScope } from "./context";
+const { withMDXComponents } = require("@mdx-js/tag/dist/mdx-provider");
+const { withMDXScope } = require("./context");
 
-export default withMDXScope(
+module.exports = withMDXScope(
   withMDXComponents(({ scope = {}, components = {}, children, ...props }) => {
     const fullScope = {
       components,

--- a/packages/gatsby-mdx/utils/render-html.js
+++ b/packages/gatsby-mdx/utils/render-html.js
@@ -1,0 +1,7 @@
+const MDXRenderer = require("../mdx-renderer");
+const React = require("react");
+const { renderToStaticMarkup } = require("react-dom/server");
+
+module.exports = function renderHTML(rawMDX) {
+  return renderToStaticMarkup(React.createElement(MDXRenderer, null, rawMDX));
+};


### PR DESCRIPTION
This fixes #139. It uses `MDXRenderer` component together with `renderToStaticMarkup` from `react-dom/server` and reuses `code` field resolver to get compiled MDX node code.