### PR TITLE
Split `genMDX` into two functions, added `renderHTML` test, fixed `renderHTML`

### DIFF
--- a/packages/gatsby-mdx/gatsby/extend-node-type.js
+++ b/packages/gatsby-mdx/gatsby/extend-node-type.js
@@ -25,7 +25,7 @@ const debug = require("debug")("gatsby-mdx:extend-node-type");
 const renderHTML = require("../utils/render-html");
 const getTableOfContents = require("../utils/get-table-of-content");
 const defaultOptions = require("../utils/default-options");
-const genMDX = require("../utils/gen-mdx");
+const { genMDXWithRemarkPlugins } = require("../utils/gen-mdx");
 
 module.exports = (
   { type /*store*/, pathPrefix, getNode, getNodes, cache, reporter },
@@ -63,7 +63,15 @@ module.exports = (
   }
 
   const processMDX = ({ node }) =>
-    genMDX({ node, getNode, getNodes, reporter, cache, pathPrefix, options });
+    genMDXWithRemarkPlugins({
+      node,
+      getNode,
+      getNodes,
+      reporter,
+      cache,
+      pathPrefix,
+      options
+    });
   return new Promise((resolve /*, reject*/) => {
     async function getText(mdxNode) {
       const { mdast } = await processMDX({ node: mdxNode });

--- a/packages/gatsby-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-mdx/utils/gen-mdx.js
@@ -40,7 +40,7 @@ const getSourcePluginsAsRemarkPlugins = require("./get-source-plugins-as-remark-
  * }
  *  */
 
-async function genMDX(node, options, babelConfig = {}) {
+async function genMDX(node, options) {
   // TODO: a remark and a hast plugin that pull out the ast and store it in results
   /* const cacheMdast = () => ast => {
    *   results.mdast = ast;
@@ -85,7 +85,7 @@ async function genMDX(node, options, babelConfig = {}) {
   debug("compiling scope");
   const instance = new BabelPluginPluckImports();
   const result = babel.transform(code, {
-    ...babelConfig,
+    configFile: false,
     plugins: [instance.plugin, objRestSpread],
     presets: [require("@babel/preset-react")]
   });

--- a/packages/gatsby-mdx/utils/render-html.js
+++ b/packages/gatsby-mdx/utils/render-html.js
@@ -1,7 +1,16 @@
 const MDXRenderer = require("../mdx-renderer");
 const React = require("react");
 const { renderToStaticMarkup } = require("react-dom/server");
+const { MDXTag } = require("@mdx-js/tag");
 
-module.exports = function renderHTML(rawMDX) {
-  return renderToStaticMarkup(React.createElement(MDXRenderer, null, rawMDX));
+module.exports = function renderHTML(rawMDX, scopeOverride) {
+  const scope = {
+    ...scopeOverride,
+    React,
+    MDXTag
+  };
+
+  return renderToStaticMarkup(
+    React.createElement(MDXRenderer, { scope }, rawMDX)
+  );
 };

--- a/packages/gatsby-mdx/utils/render-html.test.js
+++ b/packages/gatsby-mdx/utils/render-html.test.js
@@ -34,9 +34,7 @@ test("renderHTML works end-to-end", async () => {
 * World!
   `;
 
-  const { body } = await genMDX({ rawBody }, defaultOptions(), {
-    configFile: false
-  });
+  const { body } = await genMDX({ rawBody }, defaultOptions());
 
   expect(renderHTML(body)).toBe(
     "<div><h1>Hello</h1><ul><li><p>World!</p></li></ul></div>"

--- a/packages/gatsby-mdx/utils/render-html.test.js
+++ b/packages/gatsby-mdx/utils/render-html.test.js
@@ -1,0 +1,44 @@
+const renderHTML = require("./render-html");
+const { genMDX } = require("./gen-mdx");
+const defaultOptions = require("./default-options");
+
+test("renderHTML works for simple compiled MDX", async () => {
+  const renderedJS = `return () => React.createElement(MDXTag, {
+    name: "wrapper",
+    components: components
+  }, React.createElement(MDXTag, {
+    name: "h1",
+    components: components
+  }, "Hello"), React.createElement(MDXTag, {
+    name: "ul",
+    components: components
+  }, React.createElement(MDXTag, {
+    name: "li",
+    components: components,
+    parentName: "ul"
+  }, React.createElement(MDXTag, {
+    name: "p",
+    components: components,
+    parentName: "li"
+  }, "World!"))));`;
+
+  expect(renderHTML(renderedJS)).toBe(
+    "<div><h1>Hello</h1><ul><li><p>World!</p></li></ul></div>"
+  );
+});
+
+test("renderHTML works end-to-end", async () => {
+  const rawBody = `
+# Hello
+
+* World!
+  `;
+
+  const { body } = await genMDX({ rawBody }, defaultOptions(), {
+    configFile: false
+  });
+
+  expect(renderHTML(body)).toBe(
+    "<div><h1>Hello</h1><ul><li><p>World!</p></li></ul></div>"
+  );
+});


### PR DESCRIPTION
This PR splits `genMDX` into plain `genMDX` and `genMDXWithRemarkPlugins`, the latter calls `genMDX` with plugins passed from gatsby. This makes `genMDX` itself callable from tests with `defaultOptions`.

This allowed me to create `render-html.test.js` which tests rendering of simple MDX code to HTML.

This uncovered a bug, where `renderHTML` wasn't passing a correct scope to `MDXRenderer`. Now it passes scope if any and extends it with `React` and `MDXTag`, which are expected to be used in any MDX to HTML render.

This PR also adds optional `babelConfig` extender parameter to `genMDX`, which allows tests to pass custom babel config. Without this tests were failing due to having a babel config different to one that's used in real gatsby environment, it was picking up project-wide `babel.config.js` and emitting `exports...` code that caused `MDXRenderer` to fail.