### PR TITLE
Fix parsing complex style props 

### DIFF
--- a/packages/gatsby-mdx/package.json
+++ b/packages/gatsby-mdx/package.json
@@ -20,7 +20,7 @@
     "escape-string-regexp": "^1.0.5",
     "fs-extra": "^7.0.0",
     "gray-matter": "^4.0.1",
-    "@danielberndt/htmltojsx": "0.3.3",
+    "@danielberndt/htmltojsx": "0.3.4",
     "lodash": "^4.17.10",
     "mdast-util-to-string": "^1.0.4",
     "mdast-util-toc": "^2.0.1",

--- a/packages/gatsby-mdx/package.json
+++ b/packages/gatsby-mdx/package.json
@@ -20,7 +20,7 @@
     "escape-string-regexp": "^1.0.5",
     "fs-extra": "^7.0.0",
     "gray-matter": "^4.0.1",
-    "@danielberndt/htmltojsx": "0.3.2",
+    "@danielberndt/htmltojsx": "0.3.3",
     "lodash": "^4.17.10",
     "mdast-util-to-string": "^1.0.4",
     "mdast-util-toc": "^2.0.1",

--- a/packages/gatsby-mdx/package.json
+++ b/packages/gatsby-mdx/package.json
@@ -20,7 +20,7 @@
     "escape-string-regexp": "^1.0.5",
     "fs-extra": "^7.0.0",
     "gray-matter": "^4.0.1",
-    "htmltojsx": "^0.3.0",
+    "@erikwithuhk/html-to-jsx": "1.0.6",
     "lodash": "^4.17.10",
     "mdast-util-to-string": "^1.0.4",
     "mdast-util-toc": "^2.0.1",

--- a/packages/gatsby-mdx/package.json
+++ b/packages/gatsby-mdx/package.json
@@ -20,7 +20,7 @@
     "escape-string-regexp": "^1.0.5",
     "fs-extra": "^7.0.0",
     "gray-matter": "^4.0.1",
-    "@erikwithuhk/html-to-jsx": "1.0.6",
+    "@danielberndt/htmltojsx": "0.3.2",
     "lodash": "^4.17.10",
     "mdast-util-to-string": "^1.0.4",
     "mdast-util-toc": "^2.0.1",

--- a/packages/gatsby-mdx/utils/get-source-plugins-as-remark-plugins.js
+++ b/packages/gatsby-mdx/utils/get-source-plugins-as-remark-plugins.js
@@ -1,6 +1,6 @@
 const visit = require("unist-util-visit");
 const _ = require("lodash");
-const HTMLtoJSX = require("@erikwithuhk/html-to-jsx");
+const HTMLtoJSX = require("@erikwithuhk/html-to-jsx").default;
 const map = require("unist-util-map");
 const debug = require("debug")("get-source-plugins-as-remark-plugins");
 

--- a/packages/gatsby-mdx/utils/get-source-plugins-as-remark-plugins.js
+++ b/packages/gatsby-mdx/utils/get-source-plugins-as-remark-plugins.js
@@ -1,6 +1,6 @@
 const visit = require("unist-util-visit");
 const _ = require("lodash");
-const HTMLtoJSX = require("htmltojsx");
+const HTMLtoJSX = require("@erikwithuhk/html-to-jsx");
 const map = require("unist-util-map");
 const debug = require("debug")("get-source-plugins-as-remark-plugins");
 

--- a/packages/gatsby-mdx/utils/get-source-plugins-as-remark-plugins.js
+++ b/packages/gatsby-mdx/utils/get-source-plugins-as-remark-plugins.js
@@ -1,6 +1,6 @@
 const visit = require("unist-util-visit");
 const _ = require("lodash");
-const HTMLtoJSX = require("@erikwithuhk/html-to-jsx").default;
+const HTMLtoJSX = require("@danielberndt/htmltojsx");
 const map = require("unist-util-map");
 const debug = require("debug")("get-source-plugins-as-remark-plugins");
 


### PR DESCRIPTION
the version of `htmltojsx` that is being used has [an issue](https://github.com/reactjs/react-magic/issues/158) with the style prop that is being output by `gatsby-remark-images`:

```
style="padding-bottom: 75%; position: relative; bottom: 0; left: 0; background-size: cover; display: block; background-image: url('data:image/jpeg;base64,/9j/2w[...]1XP//Z');"
```

It struggles with the semicolon within the `url()` part.

Since there haven't been any releases of `htmltojsx` in a long time, I'm not too certain [my PR](https://github.com/reactjs/react-magic/pull/159) will be merged and released anytime soon. So I published a fork which fixes the issue.

This PR basically replaces the old `htmltojsx` with my fork.