### PR TITLE
Add typescript babel plugin

### DIFF
--- a/packages/gatsby-mdx/component-with-mdx-scope.js
+++ b/packages/gatsby-mdx/component-with-mdx-scope.js
@@ -19,12 +19,18 @@ module.exports = function componentWithMDXScope(
   if (typeof codeScopeAbsPaths === "string") {
     codeScopeAbsPaths = [codeScopeAbsPaths];
   }
+  const isTS = absWrapperPath.endsWith('.ts');
+  const isTSX = absWrapperPath.endsWith('.tsx');
 
   // hoist pageQuery and any other named exports
   const OGWrapper = fs.readFileSync(absWrapperPath, "utf-8");
   const instance = new BabelPluginPluckExports();
+  const plugins = [instance.plugin, syntaxObjRestSpread];
+  if (isTS || isTSX) {
+    plugins.push([typescriptPlugin, { isTSX }]);
+  }
   babel.transform(OGWrapper, {
-    plugins: [instance.plugin, syntaxObjRestSpread, [typescriptPlugin, { isTSX: true }]],
+    plugins,
     presets: [require("@babel/preset-react")]
   }).code;
 

--- a/packages/gatsby-mdx/component-with-mdx-scope.js
+++ b/packages/gatsby-mdx/component-with-mdx-scope.js
@@ -3,6 +3,7 @@ const crypto = require("crypto");
 const path = require("path");
 const babel = require("@babel/core");
 const syntaxObjRestSpread = require("@babel/plugin-syntax-object-rest-spread");
+const typescriptPlugin = require("@babel/plugin-transform-typescript");
 const debug = require("debug")("gatsby-mdx:component-with-mdx-scope");
 const slash = require("slash");
 
@@ -23,7 +24,7 @@ module.exports = function componentWithMDXScope(
   const OGWrapper = fs.readFileSync(absWrapperPath, "utf-8");
   const instance = new BabelPluginPluckExports();
   babel.transform(OGWrapper, {
-    plugins: [instance.plugin, syntaxObjRestSpread],
+    plugins: [instance.plugin, syntaxObjRestSpread, [typescriptPlugin, { isTSX: true }]],
     presets: [require("@babel/preset-react")]
   }).code;
 

--- a/packages/gatsby-mdx/package.json
+++ b/packages/gatsby-mdx/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+    "@babel/plugin-transform-typescript": "^7.1.0",
     "babel-plugin-gather-exports": "0.0.1",
     "babel-plugin-pluck-exports": "0.0.1",
     "babel-plugin-pluck-imports": "0.0.1",

--- a/packages/gatsby-mdx/package.json
+++ b/packages/gatsby-mdx/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-    "@babel/plugin-transform-typescript": "^7.1.0",
     "babel-plugin-gather-exports": "0.0.1",
     "babel-plugin-pluck-exports": "0.0.1",
     "babel-plugin-pluck-imports": "0.0.1",


### PR DESCRIPTION
Hi,

Thanks for this great library!

I'm using it together with gatsby typescript, but `componentWithMDXScope` expect file to be javascript. This just adds `plugin-transform-typescript` to strip out typings so it will work even with typescript files.