### PR TITLE
add option to define custom node types for content grouping/querying to prevent collisions

### DIFF
--- a/examples/docs/content/api-reference.mdx
+++ b/examples/docs/content/api-reference.mdx
@@ -85,3 +85,30 @@ module.exports = {
   ]
 };
 ```
+
+### Custom Types
+
+By default `gatsby-mdx` defines all mdx nodes as `Mdx` type.
+Using the option `customType` you can define a function to specify your own types.
+The function will receive the node so you can pull any value to determine various groups of nodes and give them a customized type.
+Your function should return a string, if you don't want to override all node types you can return an empty string.
+Note that `gatsby-mdx` will suffix all types with `Mdx` to make discoverability easier for internal use.
+Using the following `gatsby-config.js`
+
+```javascript
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-mdx`,
+      options: {
+        customType: node =>
+          node.relativePath.indexOf(`articles`) === 0
+            ? `Article`
+            : node.relativePath.split(`/`)[0]
+      }
+    }
+  ]
+};
+```
+
+You'll be able to query all nodes within the articles directory as `articleMdX`/`allArticleMdx`, all other nodes will get their type based on the containing directory.

--- a/examples/docs/content/api-reference.mdx
+++ b/examples/docs/content/api-reference.mdx
@@ -104,7 +104,7 @@ module.exports = {
         customType: node =>
           node.relativePath.indexOf(`articles`) === 0
             ? `Article`
-            : node.relativePath.split(`/`)[0]
+            : node.relativeDirectory
       }
     }
   ]

--- a/packages/gatsby-mdx/gatsby/on-create-node.js
+++ b/packages/gatsby-mdx/gatsby/on-create-node.js
@@ -23,7 +23,8 @@ module.exports = async (
   const mdxNode = await createMDXNode({
     id: createNodeId(`${node.id} >>> Mdx`),
     node,
-    content
+    content,
+    type: options.customType(node)
   });
 
   createNode(mdxNode);

--- a/packages/gatsby-mdx/utils/create-mdx-node.js
+++ b/packages/gatsby-mdx/utils/create-mdx-node.js
@@ -2,7 +2,7 @@ const crypto = require("crypto");
 const mdx = require("../utils/mdx");
 const extractExports = require("../utils/extract-exports");
 
-module.exports = async ({ id, node, content }) => {
+module.exports = async ({ id, node, content, type }) => {
   const code = await mdx(content);
 
   // extract all the exports
@@ -14,7 +14,7 @@ module.exports = async ({ id, node, content }) => {
     parent: node.id,
     internal: {
       content: content,
-      type: "Mdx"
+      type: `${type}Mdx`
     }
   };
 

--- a/packages/gatsby-mdx/utils/default-options.js
+++ b/packages/gatsby-mdx/utils/default-options.js
@@ -14,7 +14,8 @@ module.exports = pluginOptions => {
       hastPlugins: [],
       mdPlugins: [],
       root: process.cwd(),
-      gatsbyRemarkPlugins: []
+      gatsbyRemarkPlugins: [],
+      customType: () => ""
     },
     pluginOptions
   );


### PR DESCRIPTION
As I like to not only write my blog posts in mdx and be able to have differing value types for keys based on content type I like to be able to customize the node type.

I'm not using this in production yet myself as I'm still migrating (or trying to) from gatsby-transformer-remark, which I modified as well using a [local copy](https://github.com/GaiAma/gaiama.org/tree/master/plugins/gatsby-transformer-remark-multi-type) in the plugins directory of my site, hardcoded but I'm running it happily in production for a couple of month now. The customType function approach seems to be the most flexible one, I tried some hash map style before which is not as powerful and straightforward, at least least to me.
I'm planning to change my local gatsby-transformer-remark-multi-type to the same customType approach and pull requesting it as well as I find it very useful and it's annoying to pull package upgrades in, so I would party hard if this gets accepted 🎉 haha

That's the `api-reference.mdx` entry I added:

> By default `gatsby-mdx` defines all mdx nodes as `Mdx` type.
> Using the option `customType` you can define a function to specify your own types.
> The function will receive the node so you can pull any value to determine various groups of nodes and give them a customized type.
> Your function should return a string, if you don't want to override all node types you can return an empty string.
> Note that `gatsby-mdx` will suffix all types with `Mdx` to make discoverability easier for internal use.
> Using the following `gatsby-config.js`
> 
> ```javascript
> module.exports = {
>   plugins: [
>     {
>       resolve: `gatsby-mdx`,
>       options: {
>         customType: node =>
>           node.relativePath.indexOf(`articles`) === 0
>             ? `Article`
>             : node.relativeDirectory
>       }
>     }
>   ]
> };
> ```
> 
> You'll be able to query all nodes within the articles directory as `articleMdX`/`allArticleMdx`, all other nodes will get their type based on the containing directory.

Maybe I could extend the above api-reference to clarify the last sentence about querying, adding more context?

Let me know if you like it or not and if you have any additions, changes, ideas I could integrate, an example site for example?!

By the way, the tests error with:
```
SyntaxError: /Users/Can/Projekte/Coding/forks/gatsby-mdx/packages/gatsby-mdx/mdx-renderer.test.js: Unexpected token (23:37)

      21 |      */
      22 |     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
    > 23 |     expect(() => TestRenderer.create(<MDXRenderer />)).toThrow(TypeError);
```
You're probably aware of this, just wanted to mention that I ran the test and stumbled upon this..

**EDIT**: maybe it should be called `customizeType` or even something like `customTypePrefix`
And I could PR the remark version, to see how they like it and what they prefer over at gatsby so we can match it here