### PR TITLE
Fix a typo in querying-mdx-content-via-graphql.mdx

### DIFF
--- a/examples/docs/content/guides/querying-mdx-content-via-graphql.mdx
+++ b/examples/docs/content/guides/querying-mdx-content-via-graphql.mdx
@@ -3,7 +3,7 @@ title: "Querying MDX Content via GraphQL"
 ---
 
 MDX files sourced via `gatsby-source-filesystem` can be queried with
-`allMdx` on the root query. Like `gatsby-transformer-remark`, `gatby-mdx`
+`allMdx` on the root query. Like `gatsby-transformer-remark`, `gatsby-mdx`
 adds fields to the Mdx node including `excerpt`, `headings`,
 `timeToRead`, and `wordCount`.
 


### PR DESCRIPTION
Noticed that there was a typo in the docs, so added a fix 👍