### PR TITLE
Fix exports

### DIFF
--- a/packages/babel-plugin-gather-exports/index.js
+++ b/packages/babel-plugin-gather-exports/index.js
@@ -15,6 +15,7 @@ module.exports = class Plugin {
             const declaration = path.node.declaration;
 
             if (
+              declaration &&
               declaration.type === "VariableDeclaration" &&
               declaration.kind === "const"
             ) {

--- a/packages/babel-plugin-gather-exports/index.test.js
+++ b/packages/babel-plugin-gather-exports/index.test.js
@@ -2,7 +2,9 @@ const Plugin = require(".");
 
 const babel = require("@babel/core");
 
-const testContents = `export const hello = 'world';
+const testContents = `
+export { value } from './index';
+export const hello = 'world';
 export const another = {
   exported: "variable"
 };

--- a/packages/babel-plugin-gather-exports/index.test.js
+++ b/packages/babel-plugin-gather-exports/index.test.js
@@ -1,9 +1,7 @@
 const Plugin = require(".");
 
 const babel = require("@babel/core");
-
-const testContents = `
-export { value } from './index';
+const testContents = `export { value } from './index';
 export const hello = 'world';
 export const another = {
   exported: "variable"


### PR DESCRIPTION
Hi, i fix babel-plugin-gather-exports
it throws errors in mdx files with directly exporting imported modules

for example
```
export { dark } from "../components/themes";

Some text
```
throw

```
TypeError: Cannot read property 'type' of null
```
