### PR TITLE
fix: add null check for codeScopeAbsPaths

### DIFF
--- a/packages/gatsby-mdx/component-with-mdx-scope.js
+++ b/packages/gatsby-mdx/component-with-mdx-scope.js
@@ -15,8 +15,8 @@ module.exports = function componentWithMDXScope(
   codeScopeAbsPaths = [],
   projectRoot = process.cwd()
 ) {
-  if (typeof codeScopeAbsPaths === "string") {
-    codeScopeAbsPaths = [codeScopeAbsPaths];
+  if (!(codeScopeAbsPaths instanceof Array)) {
+    codeScopeAbsPaths = [codeScopeAbsPaths].filter(Boolean);
   }
   const isTS = absWrapperPath.endsWith(".ts");
   const isTSX = absWrapperPath.endsWith(".tsx");


### PR DESCRIPTION
I ran into a case where one of my MDX files was returning `null` for `codeScopeAbsPaths`, which was throwing an error. This fix ensures that _any_ non-Array value will be wrapped in an array, and any falsy array items will be dropped.

I ran into this bug when updating to `^0.3.1-ci.225`.