### PR TITLE
Add not correct way to add plugins

### DIFF
--- a/examples/docs/src/pages/api-reference/options/gatsby-remark-plugins.mdx
+++ b/examples/docs/src/pages/api-reference/options/gatsby-remark-plugins.mdx
@@ -33,3 +33,11 @@ gatsbyRemarkPlugins: [
   }
 ];
 ```
+
+# Not
+> direct `string` reference the plugin is currently not supported.
+
+```js
+gatsbyRemarkPlugins: [
+  `gatsby-remark-images`,
+];


### PR DESCRIPTION
I think this PR could save others who has the issue of Cannot query field "code" on type "Node".

```
  Error: Cannot query field "code" on type "Node". Did you mean to use an inline fragment on "Mdx"?                                                                                                                
  GraphQL request (13:15)                                                                                                                                                                                          
  12:               }                                                                                                                                                                                              
  13:               code {                                                                                                                                                                                         
                    ^                                                                                                                                                                                              
  14:                 scope

```