### PR TITLE
Correct path separators on Windows

### DIFF
--- a/packages/gatsby-mdx/loaders/mdx-scopes.js
+++ b/packages/gatsby-mdx/loaders/mdx-scopes.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const slash = require("slash");
 
 module.exports = () => {
   const files = fs.readdirSync("./.cache/gatsby-mdx/mdx-scopes-dir");
@@ -8,7 +9,7 @@ module.exports = () => {
     files
       .map(
         (file, i) =>
-          `const scope_${i} = require('${path.join(abs, file)}').default;`
+          `const scope_${i} = require('${slash(path.join(abs, file))}').default;`
       )
       .join("\n") +
     `export default {


### PR DESCRIPTION
This PR fixes #231 

The problem was that `path.join(abs, file)` returned a string like `C:\My Project\my-file.js`, which was then injected into the scope string, so the result was something like this:

```
const scope_1 = require("C:\My Project\my-file.js").default;
```

The backslashes in the path get interpreted as escape characters.  One solution would be to escape the backslashes by changing `path.join(abs, file)` to `path.join(abs, file).replace(/\\/g, "\\\\")`, which would produce this:

```
const scope_1 = require("C:\\My Project\\my-file.js").default;
```

But an easier solution (and the one I went with) was to use [slash](https://www.npmjs.com/package/slash), since it's already an existing dependency and is being used elsewhere in the code to convert Windows path separators to Posix-style separators.    The final result is this:

```
const scope_1 = require("C:/My Project/my-file.js").default;
```