### PR TITLE
added `npm install` to quick start documentation

### DIFF
--- a/examples/docs/src/pages/getting-started.mdx
+++ b/examples/docs/src/pages/getting-started.mdx
@@ -27,6 +27,7 @@ your site.
 
     ```sh
     cd my-mdx-starter/
+    npm install
     gatsby develop
     ```
 


### PR DESCRIPTION
These instructions were incomplete - I had to do `npm install` before this would work, so just adding this to the docs. Thanks!