### PR TITLE
#265 shouldBlockNodeFromTransformation check

### DIFF
--- a/packages/gatsby-mdx/gatsby/on-create-node.js
+++ b/packages/gatsby-mdx/gatsby/on-create-node.js
@@ -32,6 +32,11 @@ module.exports = async (
   const { createNode, createParentChildLink } = actions;
   const options = defaultOptions(pluginOptions);
 
+  // options check to stop transformation of the node
+  if (options.shouldBlockNodeFromTransformation(node)) {
+    return;
+  }
+
   // if we shouldn't process this node, then return
   if (
     !(node.internal.type === "File" && options.extensions.includes(node.ext)) &&

--- a/packages/gatsby-mdx/utils/default-options.js
+++ b/packages/gatsby-mdx/utils/default-options.js
@@ -15,7 +15,8 @@ module.exports = pluginOptions => {
       mdPlugins: [],
       root: process.cwd(),
       gatsbyRemarkPlugins: [],
-      globalScope: `export default {}`
+      globalScope: `export default {}`,
+      shouldBlockNodeFromTransformation: () => false,
     },
     pluginOptions
   );


### PR DESCRIPTION
Allows the user to specify a custom function in their options to block transformation of a node as per https://github.com/ChristopherBiscardi/gatsby-mdx/issues/265

e.g.

```
    {
      resolve: 'gatsby-source-filesystem',
      options: {
        name: 'foobar`,
        path: `${__dirname}/src/docs/`,
      },
    },
	{
      resolve: 'gatsby-mdx',
      options: {
		shouldBlockNodeFromTransformation: (node) => {
			return node.sourceInstanceName !== 'foobar';
		},
      }
    },
```

Can't see tests for options and keeping this out of docs.