### PR TITLE
Update MDXRenderer docs to detail scope prop

### DIFF
--- a/examples/docs/src/pages/api-reference/mdx-renderer.mdx
+++ b/examples/docs/src/pages/api-reference/mdx-renderer.mdx
@@ -42,6 +42,10 @@ just like a normal React component.
 
 ### Manually Providing Scope
 
+**Note** You should never need to do what is explained here under
+normal library usage. If you think you need to it is possible there
+is a bug and you should file an issue.
+
 `MDXRenderer` accepts a `scope` prop that can be used in special
 circumstances to override the imports provided to MDX content.
 Think of `scope` like an object where we have import names as keys

--- a/examples/docs/src/pages/api-reference/mdx-renderer.mdx
+++ b/examples/docs/src/pages/api-reference/mdx-renderer.mdx
@@ -40,15 +40,26 @@ just like a normal React component.
 <MDXRenderer title="My Stuff!">{mdx.code.body}</MDXRenderer>
 ```
 
-### Using External Components in MDX
+### Manually Providing Scope
 
-If your .mdx files are importing components that are "outside" your project (such as via a custom webpack alias),
-you'll likely need to provide a scope prop.
+`MDXRenderer` accepts a `scope` prop that can be used in special
+circumstances to override the imports provided to MDX content.
+Think of `scope` like an object where we have import names as keys
+and the import value as the value.
 
-`gatsby-mdx` has a loader function that you can use to load the automatically generated scopes from the .cache directory.
+An example `scope` object may look like this. Note that `React` and
+`MDXTag` are already imported by `MDXRenderer` and added to *any* 
+scope passed in. Therefore they never need to be provided in 
+practice. This is just an example.
 
 ```js
-import scopeContexts from "gatsby-mdx/loaders/mdx-scopes!";
+import React from 'react';
+import { MDXTag } from '@mdx-js/tag';
 
-<MDXRenderer scope={scopeContexts} title="My Stuff!">{mdx.code.body}</MDXRenderer>
+const scope = {
+  React: React,
+  MDXTag: MDXTag
+}
+
+<MDXRenderer scope={scope} title="My Stuff!">{mdx.code.body}</MDXRenderer>
 ```

--- a/examples/docs/src/pages/api-reference/mdx-renderer.mdx
+++ b/examples/docs/src/pages/api-reference/mdx-renderer.mdx
@@ -39,3 +39,16 @@ just like a normal React component.
 ```js
 <MDXRenderer title="My Stuff!">{mdx.code.body}</MDXRenderer>
 ```
+
+### Using External Components in MDX
+
+If your .mdx files are importing components that are "outside" your project (such as via a custom webpack alias),
+you'll likely need to provide a scope prop.
+
+`gatsby-mdx` has a loader function that you can use to load the automatically generated scopes from the .cache directory.
+
+```js
+import scopeContexts from "gatsby-mdx/loaders/mdx-scopes!";
+
+<MDXRenderer scope={scopeContexts} title="My Stuff!">{mdx.code.body}</MDXRenderer>
+```

--- a/examples/docs/src/pages/guides/programmatically-creating-pages.mdx
+++ b/examples/docs/src/pages/guides/programmatically-creating-pages.mdx
@@ -275,12 +275,13 @@ render any programmatically accessd MDX content.
 import React from "react";
 import { graphql } from "gatsby";
 import MDXRenderer from "gatsby-mdx/mdx-renderer";
+import scopeContexts from "gatsby-mdx/loaders/mdx-scopes!";
 
 function PageTemplate({ data: { mdx } }) {
   return (
     <div>
       <h1>{mdx.frontmatter.title}</h1>
-      <MDXRenderer>{mdx.code.body}</MDXRenderer>
+      <MDXRenderer scope={scopeContexts}>{mdx.code.body}</MDXRenderer>
     </div>
   );
 }

--- a/examples/docs/src/pages/guides/programmatically-creating-pages.mdx
+++ b/examples/docs/src/pages/guides/programmatically-creating-pages.mdx
@@ -275,13 +275,12 @@ render any programmatically accessd MDX content.
 import React from "react";
 import { graphql } from "gatsby";
 import MDXRenderer from "gatsby-mdx/mdx-renderer";
-import scopeContexts from "gatsby-mdx/loaders/mdx-scopes!";
 
 function PageTemplate({ data: { mdx } }) {
   return (
     <div>
       <h1>{mdx.frontmatter.title}</h1>
-      <MDXRenderer scope={scopeContexts}>{mdx.code.body}</MDXRenderer>
+      <MDXRenderer>{mdx.code.body}</MDXRenderer>
     </div>
   );
 }


### PR DESCRIPTION
Loading external components can create problems if you're
also creating pages programmatically. This change documents
how to provide the scope prop to MDXRenderer to prevent
those problems.

Further context:
https://github.com/ChristopherBiscardi/gatsby-mdx/issues/267