### PR TITLE
Fix crash on error

### DIFF
--- a/packages/gatsby-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-mdx/loaders/mdx-loader.js
@@ -162,22 +162,26 @@ ${contentWithoutFrontmatter}`;
     mdPlugins: options.mdPlugins.concat(gatsbyRemarkPluginsAsMDPlugins),
     hastPlugins: options.hastPlugins
   });
-  const result = babel.transform(code, {
-    configFile: false,
-    plugins: [
-      require("@babel/plugin-syntax-jsx"),
-      require("@babel/plugin-syntax-object-rest-spread"),
-      require("../utils/babel-plugin-html-attr-to-jsx-attr")
-    ]
-  });
-  debugMore("transformed code", result.code);
-  return callback(
-    null,
-    `import React from 'react'
-import { MDXTag } from '@mdx-js/tag'
+  try {
+    const result = babel.transform(code, {
+      configFile: false,
+      plugins: [
+        require("@babel/plugin-syntax-jsx"),
+        require("@babel/plugin-syntax-object-rest-spread"),
+        require("../utils/babel-plugin-html-attr-to-jsx-attr")
+      ]
+    });
+    debugMore("transformed code", result.code);
+    return callback(
+      null,
+      `import React from 'react'
+  import { MDXTag } from '@mdx-js/tag'
 
 
-${result.code}
-    `
-  );
+  ${result.code}
+      `
+    );
+  } catch (e) {
+    callback(e);
+  }
 };


### PR DESCRIPTION
This is more a bug report than a pull request, so I'm going to use `bug_report.md`.

When [viewing the diff, please ignore whitespace](https://github.com/ChristopherBiscardi/gatsby-mdx/pull/276/files?w=1) (you can add `?w=1` to the URL to have GitHub ignore whitespace in the diff). Effectively it's just a couple try/catch blocks.

**Describe the bug**
When you make a mistake in an MDX file, such as a syntax error, gatsby crashes.

**To Reproduce**
1. Follow instructions at https://gatsby-mdx.netlify.com/getting-started to get started with the starter kit
2. `gatsby develop`
3. Edit `index.mdx` and add `<img width=300 />`
4. Gatsby crashes with babel error:

```
➜ ~/Dev/my-mdx-starter  yarn develop
yarn run v1.12.1
$ gatsby develop
success open and validate gatsby-configs — 0.008 s
success load plugins — 0.222 s
success onPreInit — 0.445 s
success delete html and css files from previous builds — 0.028 s
success initialize cache — 0.016 s
success copy gatsby files — 0.084 s
success onPreBootstrap — 0.008 s
success source and transform nodes — 0.049 s
success building schema — 0.274 s
success createPages — 0.000 s
success createPagesStatefully — 0.199 s
success onPreExtractQueries — 0.004 s
success update schema — 0.163 s
success extract queries from components — 0.129 s
success run graphql queries — 0.071 s — 8/8 115.17 queries/second
success write out page data — 0.004 s
success write out redirect data — 0.001 s
⢀ onPostBootstrapdone generating icons for manifest
success onPostBootstrap — 0.306 s

info bootstrap finished - 3.95 s

 DONE  Compiled successfully in 2659ms                                                                                                     10:57:55 AM


You can now view gatsby-starter-mdx-basic in the browser.
  http://localhost:8000/

View GraphiQL, an in-browser IDE, to explore your site's data and schema

  http://localhost:8000/___graphql

Note that the development build is not optimized.
To create a production build, use gatsby build

ℹ ｢wdm｣:
ℹ ｢wdm｣: Compiled successfully.
 WAIT  Compiling...                                                                                                                        10:58:05 AM

ℹ ｢wdm｣: Compiling...
error UNHANDLED REJECTION


  SyntaxError: unknown: JSX value should be either an expression or a quoted JSX text (22:11)
    20 | <MDXTag name="h1" components={components}>{`Hi people`}  33m</MDXTag>
    21 | <MDXTag name="p" components={components}>{`Welcome to your new   Gatsby site!!`}</MDXTag>
  > 22 | <img width=300 />
       |            ^
    23 | <MDXTag name="p" components={components}>{`Now go build someth  ing great.`}</MDXTag>
    24 | <div style={{ maxWidth: '300px', marginBottom: '1.45  rem' }}>
    25 |   <Image />

  - index.js:4028 _class.raise
    [my-mdx-starter]/[@babel]/parser/lib/index.js:4028:15

  - index.js:3555 _class.jsxParseAttributeValue
    [my-mdx-starter]/[@babel]/parser/lib/index.js:3555:22

  - index.js:3598 _class.jsxParseAttribute
    [my-mdx-starter]/[@babel]/parser/lib/index.js:3598:46

  - index.js:3618 _class.jsxParseOpeningElementAfterName
    [my-mdx-starter]/[@babel]/parser/lib/index.js:3618:30

  - index.js:3611 _class.jsxParseOpeningElementAt
    [my-mdx-starter]/[@babel]/parser/lib/index.js:3611:19

  - index.js:3643 _class.jsxParseElementAt
    [my-mdx-starter]/[@babel]/parser/lib/index.js:3643:33

  - index.js:3659 _class.jsxParseElementAt
    [my-mdx-starter]/[@babel]/parser/lib/index.js:3659:34

  - index.js:3712 _class.jsxParseElement
    [my-mdx-starter]/[@babel]/parser/lib/index.js:3712:19

  - index.js:3719 _class.parseExprAtom
    [my-mdx-starter]/[@babel]/parser/lib/index.js:3719:21

  - index.js:6081 _class.parseExprSubscripts
    [my-mdx-starter]/[@babel]/parser/lib/index.js:6081:21

  - index.js:6060 _class.parseMaybeUnary
    [my-mdx-starter]/[@babel]/parser/lib/index.js:6060:21

  - index.js:5945 _class.parseExprOps
    [my-mdx-starter]/[@babel]/parser/lib/index.js:5945:21

  - index.js:5917 _class.parseMaybeConditional
    [my-mdx-starter]/[@babel]/parser/lib/index.js:5917:21

  - index.js:5864 _class.parseMaybeAssign
    [my-mdx-starter]/[@babel]/parser/lib/index.js:5864:21

  - index.js:5817 _class.parseExpression
    [my-mdx-starter]/[@babel]/parser/lib/index.js:5817:21

  - index.js:7836 _class.parseReturnStatement
    [my-mdx-starter]/[@babel]/parser/lib/index.js:7836:28


error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
➜ ~/Dev/my-mdx-starter
```


**Expected behavior**
Expected error to render in browser, and for me to be able to fix the error in my editor without having to restart gatsby.

**Proposed fix**
This isn't necessarily the best fix; I don't know Gatsby internals so I'm not sure how the error should be reported. However, these try/catch blocks at least allow me to continue using Gatsby and fix the error quickly rather than waiting for the entire system to restart again.