### PR TITLE
replaced spread operator in mdx-scopes with Object.assign

### DIFF
--- a/packages/gatsby-mdx/loaders/mdx-scopes.js
+++ b/packages/gatsby-mdx/loaders/mdx-scopes.js
@@ -12,8 +12,8 @@ module.exports = () => {
           `const scope_${i} = require('${slash(path.join(abs, file))}').default;`
       )
       .join("\n") +
-    `export default {
-  ${files.map((_, i) => "...scope_" + i).join(",\n")}
-}`
+      `export default 
+        Object.assign({}, ${files.map((_, i) => 'scope_' + i).join(',\n')} )
+    `
   );
 };


### PR DESCRIPTION
Fixes the errors described at https://github.com/ChristopherBiscardi/gatsby-mdx/issues/277 and 
https://github.com/ChristopherBiscardi/gatsby-mdx/issues/205#issuecomment-455886949