### PR TITLE
Docs: Fix a typo in Getting Started guide

### DIFF
--- a/examples/docs/src/pages/getting-started.mdx
+++ b/examples/docs/src/pages/getting-started.mdx
@@ -45,7 +45,7 @@ can follow these steps:
 1. **Add `gatsby-mdx`** and MDX as dependencies
 
     ```sh
-    yarn add gasby-mdx @mdx-js/mdx @mdx-js/tag
+    yarn add gatsby-mdx @mdx-js/mdx @mdx-js/tag
     ```
 
 1. **Update your `gatsby-config.js`** to use the `gatsby-mdx` plugin


### PR DESCRIPTION
`gasby-mdx` to  `gatsby-mdx`