### PR TITLE
Parse className via regex with highlighting

### DIFF
--- a/packages/mdx-utils/index.js
+++ b/packages/mdx-utils/index.js
@@ -1,3 +1,5 @@
+const extract = /language-(?<language>[a-zA-Z-]*)[{]?(?<highlight>[0-9-]*)?[}]?/;
+
 exports.preToCodeBlock = preProps => {
   if (
     // children is MDXTag
@@ -9,15 +11,31 @@ exports.preToCodeBlock = preProps => {
   ) {
     // we have a <pre><code> situation
     const {
-      children: codeString,
+      children,
       props: { className, ...props }
     } = preProps.children.props;
-
-    return {
-      codeString: codeString.trim(),
-      language: className && className.split("-")[1],
-      ...props
+    
+    const output = {
+      codeString: children.trim(),
+      language: null,
+      highlight: null,
+      ...props,
     };
+
+    // matches "language-java" & "language-java{3-4}"
+    const match = extract.exec(className);
+    
+    if (!match) {
+      return output; 
+    }
+    
+    const { language, highlight } = match.groups;
+    
+    output.language = language;
+    output.highlight = highlight || null;
+    
+    return output;
   }
+  
   return undefined;
 };

--- a/packages/mdx-utils/index.test.js
+++ b/packages/mdx-utils/index.test.js
@@ -32,11 +32,28 @@ const preProps2 = {
   }
 };
 
+const preProps3 = {
+  children: {
+    $$typeof: Symbol("react.element"),
+    props: {
+      name: "code",
+      components: {},
+      parentName: "pre",
+      props: {
+        className: "language-java{3-6}",
+      },
+      children: "const some = {}\n"
+    }
+  }
+};
+
+
 describe("preToCodeBlock", () => {
   test("preToCodeBlock works", () => {
     expect(preToCodeBlock(preProps)).toEqual({
       codeString: "const some = {}",
-      language: "js"
+      language: "js",
+      highlight: null,
     });
   });
 
@@ -44,8 +61,17 @@ describe("preToCodeBlock", () => {
     expect(preToCodeBlock(preProps2)).toEqual({
       codeString: "<button onClick={alert('clicked')}>Click Me!</button>",
       language: "js",
+      highlight: null,
       metastring: "react-live",
       "react-live": true
+    });
+  });
+  
+  test("preToCodeBlock handles language and highlight string", () => {
+    expect(preToCodeBlock(preProps2)).toEqual({
+      codeString: "const some = {}",
+      language: "java",
+      highlight: "3-6",
     });
   });
 

--- a/packages/mdx-utils/index.test.js
+++ b/packages/mdx-utils/index.test.js
@@ -40,20 +40,19 @@ const preProps3 = {
       components: {},
       parentName: "pre",
       props: {
-        className: "language-java{3-6}",
+        className: "language-java{3-6}"
       },
       children: "const some = {}\n"
     }
   }
 };
 
-
 describe("preToCodeBlock", () => {
   test("preToCodeBlock works", () => {
     expect(preToCodeBlock(preProps)).toEqual({
       codeString: "const some = {}",
       language: "js",
-      highlight: null,
+      highlight: null
     });
   });
 
@@ -66,12 +65,12 @@ describe("preToCodeBlock", () => {
       "react-live": true
     });
   });
-  
+
   test("preToCodeBlock handles language and highlight string", () => {
-    expect(preToCodeBlock(preProps2)).toEqual({
+    expect(preToCodeBlock(preProps3)).toEqual({
       codeString: "const some = {}",
       language: "java",
-      highlight: "3-6",
+      highlight: "3-6"
     });
   });
 


### PR DESCRIPTION
Hey

Coming from gatsby-remark-prismjs, I was able to add line highlighting, e.g:

```
java{4-5}
```

This change moves the preProps to use a regex to pluck out the language and also any highlight option: https://regex101.com/r/pi7S9E/1

Tests are passing.