### PR TITLE
make error messaging useful

### DIFF
--- a/packages/gatsby-mdx/utils/create-mdx-node.js
+++ b/packages/gatsby-mdx/utils/create-mdx-node.js
@@ -3,7 +3,14 @@ const mdx = require("../utils/mdx");
 const extractExports = require("../utils/extract-exports");
 
 module.exports = async ({ id, node, content }) => {
-  const code = await mdx(content);
+  let code
+  try {
+    code = await mdx(content);
+  } catch(e) {
+    // add the path of the file to simplify debugging error messages
+    e.message += `${node.absolutePath}: ${e.message}`;
+    throw e;
+  }
 
   // extract all the exports
   const { frontmatter, ...nodeExports } = extractExports(code);


### PR DESCRIPTION
**Before:**

```
error Plugin gatsby-mdx returned an error


  YAMLException: can not read a block mapping entry; a multiline key may not be an implicit key at line 6, column 12:
      description: >-
                 ^
  
  - loader.js:165 generateError
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:165:10
  
  - loader.js:171 throwError
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:171:9
  
  - loader.js:1046 readBlockMapping
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:1046:9
  
  - loader.js:1332 composeNode
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:1332:12
  
  - loader.js:1492 readDocument
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:1492:3
  
  - loader.js:1548 loadDocuments
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:1548:5
  
  - loader.js:1569 load
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:1569:19
  
  - loader.js:1591 Object.safeLoad
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:1591:10
  
  - parse.js:12 module.exports
    [kentcdodds.com]/[gray-matter]/lib/parse.js:12:17
  
  - index.js:109 parseMatter
    [kentcdodds.com]/[gray-matter]/index.js:109:17
  
  - index.js:50 matter
    [kentcdodds.com]/[gray-matter]/index.js:50:10
  
  - mdx.js:12 mdxToJsx
    [kentcdodds.com]/[gatsby-mdx]/utils/mdx.js:12:29
  
  - create-mdx-node.js:8 module.exports
    [kentcdodds.com]/[gatsby-mdx]/utils/create-mdx-node.js:8:18
  
  - on-create-node.js:53 Object.module.exports [as onCreateNode]
    [kentcdodds.com]/[gatsby-mdx]/gatsby/on-create-node.js:53:25
```

That's not remotely helpful when you have more than one or two mdx files (I have over a hundred).

**After:**

```
error Plugin gatsby-mdx returned an error


  YAMLException: /Users/kentcdodds/code/kentcdodds.com/content/blog/advanced-react-component-patterns/index.md: can not read a block mapping entry; a multiline key may not be an implicit key at line 6, column 12:
      description: >-
                 ^
  
  - loader.js:165 generateError
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:165:10
  
  - loader.js:171 throwError
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:171:9
  
  - loader.js:1046 readBlockMapping
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:1046:9
  
  - loader.js:1332 composeNode
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:1332:12
  
  - loader.js:1492 readDocument
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:1492:3
  
  - loader.js:1548 loadDocuments
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:1548:5
  
  - loader.js:1569 load
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:1569:19
  
  - loader.js:1591 Object.safeLoad
    [kentcdodds.com]/[js-yaml]/lib/js-yaml/loader.js:1591:10
  
  - parse.js:12 module.exports
    [kentcdodds.com]/[gray-matter]/lib/parse.js:12:17
  
  - index.js:109 parseMatter
    [kentcdodds.com]/[gray-matter]/index.js:109:17
  
  - index.js:50 matter
    [kentcdodds.com]/[gray-matter]/index.js:50:10
  
  - mdx.js:12 mdxToJsx
    [kentcdodds.com]/[gatsby-mdx]/utils/mdx.js:12:29
  
  - create-mdx-node.js:8 module.exports
    [kentcdodds.com]/[gatsby-mdx]/utils/create-mdx-node.js:8:18
  
  - on-create-node.js:53 Object.module.exports [as onCreateNode]
    [kentcdodds.com]/[gatsby-mdx]/gatsby/on-create-node.js:53:25
```

Having the filename makes it MUCH more debuggable.