### PR TITLE
Add @babel/present-env to fix ie11 support.

### DIFF
--- a/packages/gatsby-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-mdx/utils/gen-mdx.js
@@ -108,7 +108,16 @@ module.exports = async function genMDX({
   const result = babel.transform(code, {
     configFile: false,
     plugins: [instance.plugin, objRestSpread, htmlAttrToJSXAttr],
-    presets: [require("@babel/preset-react")]
+    presets: [
+      require("@babel/preset-react"),
+      [
+        require("@babel/preset-env"),
+        {
+          useBuiltIns: "entry",
+          modules: "false"
+        }
+      ]
+    ]
   });
 
   const identifiers = Array.from(instance.state.identifiers);
@@ -126,7 +135,7 @@ module.exports = async function genMDX({
   results.scopeIdentifiers = identifiers;
   // TODO: be more sophisticated about these replacements
   results.body = result.code
-    .replace("export default", "return")
+    .replace("export { MDXContent as default };", "return MDXContent;")
     .replace(/\nexport /g, "\n");
 
   /* results.html = renderToStaticMarkup(


### PR DESCRIPTION
Closes #301 

This fix works for me to restore IE11 compatibility to MDXRenderer.  I have implemented the fix on https://blog.tenon.io/ as a local plugin where it fixed the IE11 issues.

Babel config is not my strong suit so I have made two assumptions:

1. @babel/preset-env is already present in a Gatsby site, so I did not add it to `package.json`.
1. @babel/preset-env is already using the configuration given by `babel-preset-gatsby` and will therefore be overrideable as stated in the Gatsby docs.

Are my assumptions correct?

Thanks @ChristopherBiscardi for leading me in the right direction with your comment on the issue. For now our live site is working in IE11 👍 