### PR TITLE
use cache instead of hardcoding path

### DIFF
--- a/packages/gatsby-mdx/constants.js
+++ b/packages/gatsby-mdx/constants.js
@@ -1,11 +1,7 @@
-const path = require("path");
-
-const CACHE_LOCATION = path.join(".cache", "gatsby-mdx");
-const MDX_WRAPPERS_LOCATION = path.join(CACHE_LOCATION, "mdx-wrappers-dir");
-const MDX_SCOPES_LOCATION = path.join(CACHE_LOCATION, "mdx-scopes-dir");
+const MDX_WRAPPERS_LOCATION = "mdx-wrappers-dir";
+const MDX_SCOPES_LOCATION = "mdx-scopes-dir";
 
 module.exports = {
-  CACHE_LOCATION,
   MDX_WRAPPERS_LOCATION,
   MDX_SCOPES_LOCATION
 };

--- a/packages/gatsby-mdx/gatsby-node.js
+++ b/packages/gatsby-mdx/gatsby-node.js
@@ -45,15 +45,14 @@ exports.onCreateBabelConfig = ({ actions }) => {
   });
 };
 
-exports.onPreBootstrap = ({ store }) => {
-  const { directory } = store.getState().program;
-  mkdirp.sync(path.join(directory, MDX_SCOPES_LOCATION));
+exports.onPreBootstrap = ({ cache }) => {
+  mkdirp.sync(path.join(cache.directory, MDX_SCOPES_LOCATION));
 };
 
-exports.onPostBootstrap = (_, pluginOptions) => {
+exports.onPostBootstrap = ({ cache }, pluginOptions) => {
   if (pluginOptions.globalScope) {
     fs.writeFileSync(
-      `${MDX_SCOPES_LOCATION}/global-scope.js`,
+      path.join(cache.directory, MDX_SCOPES_LOCATION, `global-scope.js`),
       pluginOptions.globalScope
     );
   }

--- a/packages/gatsby-mdx/gatsby/create-webpack-config.js
+++ b/packages/gatsby-mdx/gatsby/create-webpack-config.js
@@ -3,7 +3,7 @@ const escapeStringRegexp = require("escape-string-regexp");
 const defaultOptions = require("../utils/default-options");
 
 module.exports = (
-  { stage, loaders, actions, plugins, ...other },
+  { stage, loaders, actions, plugins, cache, ...other },
   pluginOptions
 ) => {
   const options = defaultOptions(pluginOptions);
@@ -16,7 +16,7 @@ module.exports = (
       rules: [
         {
           test: /\.js$/,
-          include: path.resolve(__dirname, ".cache/gatsby-mdx"),
+          include: cache.directory,
           use: [loaders.js()]
         },
         {
@@ -34,6 +34,19 @@ module.exports = (
               loader: path.join("gatsby-mdx", "loaders", "mdx-components"),
               options: {
                 plugins: options.mdxPlugins
+              }
+            }
+          ]
+        },
+        {
+          test: /mdx-scopes\.js$/,
+          include: path.dirname(require.resolve("gatsby-mdx")),
+          use: [
+            loaders.js(),
+            {
+              loader: path.join("gatsby-mdx", "loaders", "mdx-scopes"),
+              options: {
+                cache: cache
               }
             }
           ]
@@ -58,6 +71,7 @@ module.exports = (
             {
               loader: path.join("gatsby-mdx", "loaders", "mdx-loader"),
               options: {
+                cache: cache,
                 ...other,
                 pluginOptions: options
               }

--- a/packages/gatsby-mdx/loaders/mdx-scopes.js
+++ b/packages/gatsby-mdx/loaders/mdx-scopes.js
@@ -1,19 +1,24 @@
 const fs = require("fs");
 const path = require("path");
 const slash = require("slash");
+const loaderUtils = require("loader-utils");
+const { MDX_SCOPES_LOCATION } = require("../constants");
 
 module.exports = () => {
-  const files = fs.readdirSync("./.cache/gatsby-mdx/mdx-scopes-dir");
-  const abs = path.resolve("./.cache/gatsby-mdx/mdx-scopes-dir");
+  const { cache } = loaderUtils.getOptions(this);
+  const abs = path.join(cache.directory, MDX_SCOPES_LOCATION);
+  const files = fs.readdirSync(abs);
   return (
     files
       .map(
         (file, i) =>
-          `const scope_${i} = require('${slash(path.join(abs, file))}').default;`
+          `const scope_${i} = require('${slash(
+            path.join(abs, file)
+          )}').default;`
       )
       .join("\n") +
-      `export default 
-        Object.assign({}, ${files.map((_, i) => 'scope_' + i).join(',\n')} )
+    `export default
+        Object.assign({}, ${files.map((_, i) => "scope_" + i).join(",\n")} )
     `
   );
 };

--- a/packages/gatsby-mdx/loaders/mdx-scopes.js
+++ b/packages/gatsby-mdx/loaders/mdx-scopes.js
@@ -4,7 +4,7 @@ const slash = require("slash");
 const loaderUtils = require("loader-utils");
 const { MDX_SCOPES_LOCATION } = require("../constants");
 
-module.exports = () => {
+module.exports = function() {
   const { cache } = loaderUtils.getOptions(this);
   const abs = path.join(cache.directory, MDX_SCOPES_LOCATION);
   const files = fs.readdirSync(abs);

--- a/packages/gatsby-mdx/utils/wrap-root-render-html-entry.js
+++ b/packages/gatsby-mdx/utils/wrap-root-render-html-entry.js
@@ -1,7 +1,7 @@
 /* global __MDX_CONTENT__ */
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import scopeContexts from "../loaders/mdx-scopes!";
+import scopeContexts from "../loaders/mdx-scopes";
 import MDXRenderer from "../mdx-renderer";
 import { plugins as wrappers } from "../loaders/mdx-wrappers";
 import { pipe } from "lodash/fp";

--- a/packages/gatsby-mdx/wrap-root-element.js
+++ b/packages/gatsby-mdx/wrap-root-element.js
@@ -2,9 +2,7 @@ import React from "react";
 import { MDXProvider } from "@mdx-js/tag";
 import { withMDXComponents } from "@mdx-js/tag/dist/mdx-provider";
 import { MDXScopeProvider } from "./context";
-// this import, unlike the more complicated one below, executes the
-// mdx-scopes loader with no arguments. No funny-business.
-import scopeContexts from "./loaders/mdx-scopes!";
+
 /**
  * so, this import is weird right?
  *
@@ -27,6 +25,7 @@ import scopeContexts from "./loaders/mdx-scopes!";
  * Submit a PR
  */
 import { plugins as mdxPlugins } from "./loaders/mdx-components";
+import scopeContexts from "./loaders/mdx-scopes";
 
 const componentsAndGuards = {};
 


### PR DESCRIPTION
Gatsby might introduce a way at some point to specify the .cache folder location at some point so instead of hardcoding `.cache/gatsby-mdx` in a bunch of places, we should use the `cache` object instead to be future proof