### PR TITLE
improved MDXContent export replacement

### DIFF
--- a/packages/gatsby-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-mdx/utils/gen-mdx.js
@@ -146,7 +146,7 @@ module.exports = async function genMDX({
   results.scopeIdentifiers = identifiers;
   // TODO: be more sophisticated about these replacements
   results.body = result.code
-    .replace("export { MDXContent as default };", "return MDXContent;")
+    .replace(/export\s*{\s*MDXContent\s+as\s+default\s*};?/, "return MDXContent;")
     .replace(/\nexport /g, "\n");
 
   /* results.html = renderToStaticMarkup(


### PR DESCRIPTION
I'm hitting an issue where I get the following error. 

```
2:59:15 PM:   SyntaxError: Unexpected token export
2:59:15 PM:   
2:59:15 PM:   - new Function
2:59:15 PM:   
2:59:15 PM:   - render-page.js:17650 ./node_modules/gatsby-mdx/mdx-renderer.js.module.export    s.withMDXComponents
2:59:15 PM:     /opt/build/repo/public/render-page.js:17650:46
2:59:15 PM:   
```

The generated `code.body` field ends with the following:
```
return MDXContent;}(React.Component);export{MDXContent as default};MDXContent.isMDXComponent=true;
```

The missing whitespace around the export makes the replace not work.

This is a small change to make the export replacement match cases where there is a difference in whitespace.