### PR TITLE
Allow non-page MDX files to use defaultLayouts

### DIFF
--- a/examples/kitchen-sink/content/non-page-default-layout.mdx
+++ b/examples/kitchen-sink/content/non-page-default-layout.mdx
@@ -1,0 +1,1 @@
+Some content

--- a/examples/kitchen-sink/gatsby-config.js
+++ b/examples/kitchen-sink/gatsby-config.js
@@ -14,7 +14,10 @@ module.exports = {
         export default { Picker: SketchPicker }`,
         defaultLayouts: {
           posts: require.resolve("./src/components/default-post-layout.js"),
-          default: require.resolve("./src/components/default-page-layout.js")
+          default: require.resolve("./src/components/default-page-layout.js"),
+          ["non-page-default-layout"]: require.resolve(
+            "./src/components/non-page-default-post-layout.js"
+          )
         }
       }
     },
@@ -23,6 +26,13 @@ module.exports = {
       options: {
         name: "posts",
         path: `${__dirname}/content/`
+      }
+    },
+    {
+      resolve: "gatsby-source-filesystem",
+      options: {
+        name: "non-page-default-layout",
+        path: `${__dirname}/content/non-page-default-layout.mdx`
       }
     },
     "gatsby-transformer-remark",

--- a/examples/kitchen-sink/src/components/non-page-default-post-layout.js
+++ b/examples/kitchen-sink/src/components/non-page-default-post-layout.js
@@ -1,0 +1,12 @@
+import React, { Component } from "react";
+
+export default class DefaultPageLayout extends Component {
+  render() {
+    return (
+      <div>
+        <h1>The Non-page Default Post Layout</h1>
+        <div>{this.props.children}</div>
+      </div>
+    );
+  }
+}

--- a/examples/kitchen-sink/src/pages/non-page-default-layout.js
+++ b/examples/kitchen-sink/src/pages/non-page-default-layout.js
@@ -1,0 +1,32 @@
+import React, { Fragment } from "react";
+import { graphql } from "gatsby";
+import { MDXRenderer } from "gatsby-mdx";
+
+export default function NonPageDefaultLayout({ data: { allMdx } }) {
+  const node = allMdx.edges[0];
+
+  return (
+    <Fragment>
+      <MDXRenderer>{node.code.body}</MDXRenderer>
+    </Fragment>
+  );
+}
+
+export const pageQuery = graphql`
+  {
+    allMdx(
+      filter: {
+        fileAbsolutePath: { regex: "/content/non-page-default-layout.mdx$/" }
+      }
+    ) {
+      edges {
+        node {
+          id
+          code {
+            body
+          }
+        }
+      }
+    }
+  }
+`;

--- a/packages/gatsby-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-mdx/loaders/mdx-loader.js
@@ -1,87 +1,12 @@
-const _ = require("lodash");
 const { getOptions } = require("loader-utils");
-const grayMatter = require("gray-matter");
-const unified = require("unified");
 const babel = require("@babel/core");
 
-const {
-  isImport,
-  isExport,
-  isExportDefault,
-  BLOCKS_REGEX,
-  EMPTY_NEWLINE
-} = require("@mdx-js/mdx/util");
-
-const toMDAST = require("remark-parse");
-const squeeze = require("remark-squeeze-paragraphs");
-const debug = require("debug")("gatsby-mdx:mdx-loader");
 const debugMore = require("debug")("gatsby-mdx-info:mdx-loader");
 
 const genMdx = require("../utils/gen-mdx");
 const withDefaultOptions = require("../utils/default-options");
 const createMDXNode = require("../utils/create-mdx-node");
 const { createFileNode } = require("../utils/create-fake-file-node");
-const slash = require("slash");
-
-const DEFAULT_OPTIONS = {
-  footnotes: true,
-  remarkPlugins: [],
-  rehypePlugins: [],
-  compilers: [],
-  blocks: [BLOCKS_REGEX]
-};
-
-/**
- * TODO: Find a way to PR all of this code that was lifted
- * from @mdx-js/mdx back into mdx with the modifications. We
- * don't want to maintain subtly different parsing code if we
- * can avoid it.
- */
-const hasDefaultExport = (str, options) => {
-  let hasDefaultExportBool = false;
-
-  function getDefaultExportBlock(subvalue) {
-    const isDefault = isExportDefault(subvalue);
-    hasDefaultExportBool = hasDefaultExportBool || isDefault;
-    return isDefault;
-  }
-  const tokenizeEsSyntax = (eat, value) => {
-    const index = value.indexOf(EMPTY_NEWLINE);
-    const subvalue = value.slice(0, index);
-
-    if (isExport(subvalue) || isImport(subvalue)) {
-      return eat(subvalue)({
-        type: isExport(subvalue) ? "export" : "import",
-        default: getDefaultExportBlock(subvalue),
-        value: subvalue
-      });
-    }
-  };
-
-  tokenizeEsSyntax.locator = value => {
-    return isExport(value) || isImport(value) ? -1 : 1;
-  };
-
-  function esSyntax() {
-    var Parser = this.Parser;
-    var tokenizers = Parser.prototype.blockTokenizers;
-    var methods = Parser.prototype.blockMethods;
-
-    tokenizers.esSyntax = tokenizeEsSyntax;
-
-    methods.splice(methods.indexOf("paragraph"), 0, "esSyntax");
-  }
-
-  const { content } = grayMatter(str);
-  unified()
-    .use(toMDAST, options)
-    .use(esSyntax)
-    .use(squeeze, options)
-    .parse(content)
-    .toString();
-
-  return hasDefaultExportBool;
-};
 
 module.exports = async function(content) {
   const callback = this.async();
@@ -109,37 +34,11 @@ module.exports = async function(content) {
     isFakeFileNode = true;
   }
 
-  const source = fileNode && fileNode.sourceInstanceName;
-
   const mdxNode = await createMDXNode({
     id: "fakeNodeIdMDXFileABugIfYouSeeThis",
     node: fileNode,
     content
   });
-
-  // get the default layout for the file source group, or if it doesn't
-  // exist, the overall default layout
-  const defaultLayout = _.get(
-    options.defaultLayouts,
-    source,
-    _.get(options.defaultLayouts, "default")
-  );
-
-  let code = content;
-  // after running mdx, the code *always* has a default export, so this
-  // check needs to happen first.
-  if (!hasDefaultExport(content, DEFAULT_OPTIONS) && !!defaultLayout) {
-    debug("inserting default layout", defaultLayout);
-    const { content: contentWithoutFrontmatter, matter } = grayMatter(content);
-
-    code = `${matter ? matter : ""}
-
-import DefaultLayout from "${slash(defaultLayout)}"
-
-export default DefaultLayout
-
-${contentWithoutFrontmatter}`;
-  }
 
   const getNode = id => {
     if (isFakeFileNode && id === fileNode.id) {
@@ -152,7 +51,7 @@ ${contentWithoutFrontmatter}`;
   const { rawMDXOutput } = await genMdx({
     isLoader: true,
     options,
-    node: { ...mdxNode, rawBody: code },
+    node: { ...mdxNode, rawBody: content },
     getNode,
     getNodes,
     reporter,

--- a/packages/gatsby-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-mdx/utils/gen-mdx.js
@@ -1,13 +1,86 @@
+const _ = require("lodash");
 const babel = require("@babel/core");
 const grayMatter = require("gray-matter");
 const mdx = require("@mdx-js/mdx");
 const objRestSpread = require("@babel/plugin-proposal-object-rest-spread");
+
+const slash = require("slash");
+const unified = require("unified");
+const squeeze = require("remark-squeeze-paragraphs");
+const toMDAST = require("remark-parse");
+const {
+  isImport,
+  isExport,
+  isExportDefault,
+  BLOCKS_REGEX,
+  EMPTY_NEWLINE
+} = require("@mdx-js/mdx/util");
 
 const debug = require("debug")("gatsby-mdx:gen-mdx");
 
 const getSourcePluginsAsRemarkPlugins = require("./get-source-plugins-as-remark-plugins");
 const htmlAttrToJSXAttr = require("./babel-plugin-html-attr-to-jsx-attr");
 const BabelPluginPluckImports = require("./babel-plugin-pluck-imports");
+
+const DEFAULT_OPTIONS = {
+  footnotes: true,
+  remarkPlugins: [],
+  rehypePlugins: [],
+  compilers: [],
+  blocks: [BLOCKS_REGEX]
+};
+
+/**
+ * TODO: Find a way to PR all of this code that was lifted
+ * from @mdx-js/mdx back into mdx with the modifications. We
+ * don't want to maintain subtly different parsing code if we
+ * can avoid it.
+ */
+const hasDefaultExport = (str, options) => {
+  let hasDefaultExportBool = false;
+
+  function getDefaultExportBlock(subvalue) {
+    const isDefault = isExportDefault(subvalue);
+    hasDefaultExportBool = hasDefaultExportBool || isDefault;
+    return isDefault;
+  }
+  const tokenizeEsSyntax = (eat, value) => {
+    const index = value.indexOf(EMPTY_NEWLINE);
+    const subvalue = value.slice(0, index);
+
+    if (isExport(subvalue) || isImport(subvalue)) {
+      return eat(subvalue)({
+        type: isExport(subvalue) ? "export" : "import",
+        default: getDefaultExportBlock(subvalue),
+        value: subvalue
+      });
+    }
+  };
+
+  tokenizeEsSyntax.locator = value => {
+    return isExport(value) || isImport(value) ? -1 : 1;
+  };
+
+  function esSyntax() {
+    var Parser = this.Parser;
+    var tokenizers = Parser.prototype.blockTokenizers;
+    var methods = Parser.prototype.blockMethods;
+
+    tokenizers.esSyntax = tokenizeEsSyntax;
+
+    methods.splice(methods.indexOf("paragraph"), 0, "esSyntax");
+  }
+
+  const { content } = grayMatter(str);
+  unified()
+    .use(toMDAST, options)
+    .use(esSyntax)
+    .use(squeeze, options)
+    .parse(content)
+    .toString();
+
+  return hasDefaultExportBool;
+};
 
 /*
  * function mutateNode({
@@ -114,8 +187,36 @@ export const _frontmatter = ${JSON.stringify(data)}`;
     }
   );
 
+  const parent = node.parent && getNode(node.parent);
+  const source =
+    parent && parent.internal.type === `File` && parent.sourceInstanceName;
+
+  // get the default layout for the file source group, or if it doesn't
+  // exist, the overall default layout
+  const defaultLayout = _.get(
+    options.defaultLayouts,
+    source,
+    _.get(options.defaultLayouts, "default")
+  );
+
+  let code = content;
+  // after running mdx, the code *always* has a default export, so this
+  // check needs to happen first.
+  if (!hasDefaultExport(content, DEFAULT_OPTIONS) && !!defaultLayout) {
+    debug("inserting default layout", defaultLayout);
+    const { content: contentWithoutFrontmatter, matter } = grayMatter(content);
+
+    code = `${matter ? matter : ""}
+
+import DefaultLayout from "${slash(defaultLayout)}"
+
+export default DefaultLayout
+
+${contentWithoutFrontmatter}`;
+  }
+
   debug("running mdx");
-  let code = await mdx(content, {
+  code = await mdx(code, {
     ...options,
     remarkPlugins: options.remarkPlugins.concat(
       gatsbyRemarkPluginsAsremarkPlugins


### PR DESCRIPTION
To my surprise, `defaultLayouts` doesn't apply to non-page mdx files. This PR abstracts the `defaultLayouts` logic into `genMdx` and out of mdx loader.

I also added a quick test page to the kitchen sink example.

If you need anything else or want anything changed let me know. I put this together quickly so there might be a mistake.