### PR TITLE
Don't use default value for scope and components

### DIFF
--- a/packages/gatsby-mdx/mdx-renderer.js
+++ b/packages/gatsby-mdx/mdx-renderer.js
@@ -3,8 +3,8 @@ const { useMDXComponents, mdx } = require("@mdx-js/react");
 const { useMDXScope } = require("./context");
 
 module.exports = function MDXRenderer({
-  scope = {},
-  components = {},
+  scope,
+  components,
   children,
   ...props
 }) {


### PR DESCRIPTION
We need to remove these default values or merge the scope in `useMDXScope`. Sorry that I didn't catch this when doing the hooks refactor