### PR TITLE
disable cache gen-mdx temporarily to fix #350

### DIFF
--- a/packages/gatsby-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-mdx/utils/gen-mdx.js
@@ -54,10 +54,10 @@ module.exports = async function genMDX({
       node.internal.contentDigest
     }-${pathPrefixCacheStr}`;
 
-  const cachedPayload = await cache.get(payloadCacheKey(node));
-  if (cachedPayload) {
-    return cachedPayload;
-  }
+//   const cachedPayload = await cache.get(payloadCacheKey(node));
+//   if (cachedPayload) {
+//     return cachedPayload;
+//   }
 
   let results = {
     mdast: undefined,
@@ -169,6 +169,6 @@ ${code}`;
   /* results.html = renderToStaticMarkup(
    *   React.createElement(MDXRenderer, null, results.body)
    * ); */
-  cache.set(payloadCacheKey(node), results);
+//   cache.set(payloadCacheKey(node), results);
   return results;
 };

--- a/packages/gatsby-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-mdx/utils/gen-mdx.js
@@ -48,11 +48,11 @@ module.exports = async function genMDX({
   cache,
   pathPrefix
 }) {
-  const pathPrefixCacheStr = pathPrefix || ``;
-  const payloadCacheKey = node =>
-    `gatsby-mdx-entire-payload-${
-      node.internal.contentDigest
-    }-${pathPrefixCacheStr}`;
+//   const pathPrefixCacheStr = pathPrefix || ``;
+//   const payloadCacheKey = node =>
+//     `gatsby-mdx-entire-payload-${
+//       node.internal.contentDigest
+//     }-${pathPrefixCacheStr}`;
 
 //   const cachedPayload = await cache.get(payloadCacheKey(node));
 //   if (cachedPayload) {


### PR DESCRIPTION
Fixs #350 

This is a temporary fix. We need discuss the design of cache for gen-mdx.

### Why plugins works well before v4.4.0?

When we run `gatsby develop`, gatsby core will call `onCreateNode` first, then `setFieldsOnGraphQLNodeType`. And in those two function, gatsby-mdx will call `genMdx` several times.

https://github.com/ChristopherBiscardi/gatsby-mdx/blob/da59df921cb9cf4193a2f85963310d2832b4db8d/packages/gatsby-mdx/utils/get-source-plugins-as-remark-plugins.js#L43-L51

https://github.com/ChristopherBiscardi/gatsby-mdx/blob/da59df921cb9cf4193a2f85963310d2832b4db8d/packages/gatsby-mdx/gatsby/extend-node-type.js#L37-L59

Both handle `gatsbyRemarkPlugins`, but the later is correct in my case. In mdx, it use `remark` directly, we do not export the AST, so just need `setParserPlugins` of `gatsby-remark-*`.

https://github.com/ChristopherBiscardi/gatsby-mdx/blob/da59df921cb9cf4193a2f85963310d2832b4db8d/packages/gatsby-mdx/utils/gen-mdx.js#L118-L123

Start from v4.4.0, we cached the `genMdx` result with incorrect plugins. It's the problem.