### PR TITLE
Fix match check to avoid null errors

### DIFF
--- a/packages/mdx-utils/index.js
+++ b/packages/mdx-utils/index.js
@@ -14,12 +14,12 @@ exports.preToCodeBlock = preProps => {
       ...props
     } = preProps.children.props;
 
-    const [, match] = className.match(/language-([\0-\uFFFF]*)/);
+    const match = className.match(/language-([\0-\uFFFF]*)/);
 
     return {
       codeString: codeString.trim(),
       className,
-      language: match ? match : "",
+      language: match != null ? match[1] : "",
       ...props
     };
   }


### PR DESCRIPTION
This was changed here #369, but [`String#match` will return Array or `null` if there is no match](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#Return_value) which will throw if you don't have a language specified for your code block

This will throw because there is no language specified for the code block.

~~~
```
foo
```
~~~

_Note: Tests were already failing before the change too_