### PR TITLE
Allow webpack loaders for relative imports

### DIFF
--- a/packages/gatsby-mdx/gatsby/on-create-node.js
+++ b/packages/gatsby-mdx/gatsby/on-create-node.js
@@ -125,10 +125,9 @@ class BabelPluginTransformRelativeImports {
       return {
         visitor: {
           StringLiteral({ node }) {
-            const loaders = node.value.indexOf("!./") > 0
-              ? node.value.replace(/(.*!)\.\/.*/, "$1")
-              : '';
-            const nodePath = node.value.replace(/.*!(\.\/.*)/, "$1");
+            let split = node.value.split('!');
+            const nodePath = split.pop();
+            const loaders = `${split.join('!')}${split.length > 0 ? '!' : ''}`;
             if (nodePath.startsWith(".")) {
               const valueAbsPath = path.resolve(parentFilepath, nodePath);
               const replacementPath = loaders + path.relative(

--- a/packages/gatsby-mdx/gatsby/on-create-node.js
+++ b/packages/gatsby-mdx/gatsby/on-create-node.js
@@ -125,9 +125,13 @@ class BabelPluginTransformRelativeImports {
       return {
         visitor: {
           StringLiteral({ node }) {
-            if (node.value.startsWith(".")) {
-              const valueAbsPath = path.resolve(parentFilepath, node.value);
-              const replacementPath = path.relative(
+            const loaders = node.value.indexOf("!./") > 0
+              ? node.value.replace(/(.*!)\.\/.*/, "$1")
+              : '';
+            const nodePath = node.value.replace(/.*!(\.\/.*)/, "$1");
+            if (nodePath.startsWith(".")) {
+              const valueAbsPath = path.resolve(parentFilepath, nodePath);
+              const replacementPath = loaders + path.relative(
                 path.join(cache.directory, MDX_SCOPES_LOCATION),
                 valueAbsPath
               );


### PR DESCRIPTION
I need to use a custom webpack loader for a relative import, and I didn't want to create aliases to every path.