### PR TITLE
docs: add new dep to install instructions

### DIFF
--- a/examples/docs/src/pages/getting-started.mdx
+++ b/examples/docs/src/pages/getting-started.mdx
@@ -45,7 +45,7 @@ can follow these steps:
 1. **Add `gatsby-mdx`** and MDX as dependencies
 
     ```sh
-    yarn add gatsby-mdx @mdx-js/mdx @mdx-js/tag
+    yarn add gatsby-mdx @mdx-js/mdx @mdx-js/tag @mdx-js/react
     ```
 
 1. **Update your `gatsby-config.js`** to use the `gatsby-mdx` plugin

--- a/examples/docs/src/pages/getting-started.mdx
+++ b/examples/docs/src/pages/getting-started.mdx
@@ -45,7 +45,7 @@ can follow these steps:
 1. **Add `gatsby-mdx`** and MDX as dependencies
 
     ```sh
-    yarn add gatsby-mdx @mdx-js/mdx @mdx-js/tag @mdx-js/react
+    yarn add gatsby-mdx @mdx-js/mdx @mdx-js/react
     ```
 
 1. **Update your `gatsby-config.js`** to use the `gatsby-mdx` plugin


### PR DESCRIPTION
I know these docs are going away soon, but I tripped over this today.