### PR TITLE
Add "homepage" element to package.json

### DIFF
--- a/packages/gatsby-mdx/package.json
+++ b/packages/gatsby-mdx/package.json
@@ -4,6 +4,7 @@
   "description": "mdx integration for gatsby",
   "main": "index.js",
   "license": "MIT",
+  "homepage": "https://github.com/ChristopherBiscardi/gatsby-mdx/tree/master/packages/gatsby-mdx#readme",
   "scripts": {
     "test": "jest"
   },


### PR DESCRIPTION
This includes a link to the package's folder in this repo, specifically scrolling to its README, [just like the official Gatsby packages do](https://github.com/gatsbyjs/gatsby/blob/182d8e4bfdefb4cc8db8c1dd279b311bf71755dd/packages/gatsby/package.json#L154).

This information is used by certain tools, e.g. in the output of `yarn outdated`.