### PR TITLE
add `pathPrefix` in the example

### DIFF
--- a/examples/docs/src/pages/guides/programmatically-creating-pages.mdx
+++ b/examples/docs/src/pages/guides/programmatically-creating-pages.mdx
@@ -174,7 +174,7 @@ slugs instead of the generated field, replace `fields` with `frontmatter`.
 // in gatsby-node.js
 const path = require("path");
 
-exports.createPages = ({ graphql, actions }) => {
+exports.createPages = ({ graphql, actions, pathPrefix }) => {
   // Destructure the createPage function from the actions object
   const { createPage } = actions;
 
@@ -207,7 +207,7 @@ exports.createPages = ({ graphql, actions }) => {
           createPage({
             // This is the slug we created before
             // (or `node.frontmatter.slug`)
-            path: node.fields.slug,
+            path: `${pathPrefix}${node.fields.slug}`,
             // This component will wrap our MDX content
             component: path.resolve(`./src/components/posts-page-layout.js`),
             // We can use the values in this context in

--- a/examples/docs/src/pages/guides/programmatically-creating-pages.mdx
+++ b/examples/docs/src/pages/guides/programmatically-creating-pages.mdx
@@ -199,7 +199,7 @@ exports.createPages = ({ graphql, actions, pathPrefix }) => {
         // this is some boilerlate to handle errors
         if (result.errors) {
           console.error(result.errors);
-          reject(result.errors);
+          throw new Error(result.errors[0]);
         }
 
         // We'll call `createPage` for each result


### PR DESCRIPTION
Could prevent a few headaches trying to figure out why there are some 404s when using a pathPrefix.

I'd also say that the example should use `reporter.error` instead of `console.error` but that's less important 