### PR TITLE
Usable AutoLinkHeader

### DIFF
--- a/packages/mdx-component-autolink-header/src/index.js
+++ b/packages/mdx-component-autolink-header/src/index.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo } from "./node_modules/react";
-import GHSlugger from "../node_modules/github-slugger";
+import React, { useEffect, useMemo } from "react";
+import GHSlugger from "github-slugger";
 
 const slugger = new GHSlugger();
 

--- a/packages/mdx-component-autolink-header/src/index.js
+++ b/packages/mdx-component-autolink-header/src/index.js
@@ -1,11 +1,24 @@
-import React from "react";
-import GHSlugger from "github-slugger";
+import React, { useEffect, useMemo } from "./node_modules/react";
+import GHSlugger from "../node_modules/github-slugger";
+
 const slugger = new GHSlugger();
 
-const AutoLinkHeader = ({ is: Component, ...props }) => (
-  <Component id={slugger.slug(props.children)} {...props} />
-);
+const SluggerReseter = ({ children }) => {
+  useEffect(() => {
+    slugger.reset();
+  }, []);
 
-AutoLinkHeader.defaultProps = { is: "h2" };
+  return children;
+};
 
+const AutoLinkHeader = ({ as: Component = "h2", id, ...props }) => {
+  const autoId = useMemo(() => slugger.slug(id || props.children), [
+    id,
+    props.children
+  ]);
+
+  return <Component id={autoId} {...props} />;
+};
+
+export { SluggerReseter, AutoLinkHeader };
 export default AutoLinkHeader;

--- a/packages/mdx-component-autolink-header/src/index.test.js
+++ b/packages/mdx-component-autolink-header/src/index.test.js
@@ -1,7 +1,7 @@
-import React from "react";
-import renderer from "react-test-renderer";
+import React from "./node_modules/react";
+import renderer from "./node_modules/react-test-renderer";
 
-import C from ".";
+import C, { SluggerReseter } from ".";
 
 describe("mdx-component-autolink-header", () => {
   it("renders with a slug", () => {
@@ -9,7 +9,8 @@ describe("mdx-component-autolink-header", () => {
       .fill(undefined)
       .map((_, index) => {
         const i = index + 1;
-        const result = renderer.create(<C is={`h${i}`}>Test Header</C>);
+        const result = renderer.create(<C as={`h${i}`}>Test Header</C>);
+
         expect(result.toJSON()).toEqual({
           type: `h${i}`,
           props: { id: index ? `test-header-${index}` : "test-header" },
@@ -25,5 +26,42 @@ describe("mdx-component-autolink-header", () => {
       props: { id: "test-header-6" },
       children: ["Test Header"]
     });
+  });
+
+  it("dont generate new ids when renders", () => {
+    // reset slug before test
+    let result = renderer.create(<SluggerReseter>RETURN</SluggerReseter>);
+    expect(result.toJSON()).toEqual("RETURN");
+
+    result = renderer.create(
+      // reset slug after test
+      <SluggerReseter>
+        <C>Test Header</C>
+        <C>Test Header</C>
+        <C>Test Header</C>
+      </SluggerReseter>
+    );
+
+    expect(result.toJSON()).toEqual([
+      { type: "h2", props: { id: "test-header" }, children: ["Test Header"] },
+      { type: "h2", props: { id: "test-header-1" }, children: ["Test Header"] },
+      { type: "h2", props: { id: "test-header-2" }, children: ["Test Header"] }
+    ]);
+  });
+
+  it("work fine with provided ids", () => {
+    const result = renderer.create(
+      <SluggerReseter>
+        <C>Test Header</C>
+        <C id="test-header">Test Header</C>
+        <C id="custom-header">Test Header</C>
+      </SluggerReseter>
+    );
+
+    expect(result.toJSON()).toEqual([
+      { type: "h2", props: { id: "test-header" }, children: ["Test Header"] },
+      { type: "h2", props: { id: "test-header-1" }, children: ["Test Header"] },
+      { type: "h2", props: { id: "custom-header" }, children: ["Test Header"] }
+    ]);
   });
 });

--- a/packages/mdx-component-autolink-header/src/index.test.js
+++ b/packages/mdx-component-autolink-header/src/index.test.js
@@ -1,5 +1,5 @@
-import React from "./node_modules/react";
-import renderer from "./node_modules/react-test-renderer";
+import React from "react";
+import renderer from "react-test-renderer";
 
 import C, { SluggerReseter } from ".";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14244,6 +14244,11 @@ mdurl@^1.0.1:
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
+mdx-utils@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/mdx-utils/-/mdx-utils-0.0.2.tgz#fec44f646b0a7904b6c63cf9ddc383407718221a"
+  integrity sha512-FUjsLYlX7kXh/xxGhqGP+Pr6rq+//RyG5Zpn9zaSOstTW/iueHFRCVlJ9p9nnChfYIOwfQTMfionMtDTrm+7yw==
+
 meant@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/meant/-/meant-1.0.1.tgz#66044fea2f23230ec806fb515efea29c44d2115d"


### PR DESCRIPTION
Hello everyone

In this PR I made
- provider for resets GHSlugger (resets slugger after render document)
- add id prop to AutoLinkHeader for customs ids
- tests
- change is to as

with shortcodes its super powerful changes

You can provide headers to document, and use them as markdown with autogenerated ids or as jsx components and provide custom ids 🙌🏻

