### PR TITLE
programmatically-creating-pages - path.rsolve  require.resolve

### DIFF
--- a/examples/docs/src/pages/guides/programmatically-creating-pages.mdx
+++ b/examples/docs/src/pages/guides/programmatically-creating-pages.mdx
@@ -209,7 +209,7 @@ exports.createPages = ({ graphql, actions }) => {
             // (or `node.frontmatter.slug`)
             path: node.fields.slug,
             // This component will wrap our MDX content
-            component: path.resolve(`./src/components/posts-page-layout.js`),
+            component: require.resolve(`./src/components/posts-page-layout.js`),
             // We can use the values in this context in
             // our page layout component
             context: { id: node.id }


### PR DESCRIPTION
path.resolve doesnt work and produces the error - The plugin "my-theme" tried to create a page that doesnt exist". Changed to require.resolve and it works. 

This was following the docs C/P