### PR TITLE
In documentation for MDXProvider, use import from @mdx-js/react

### DIFF
--- a/examples/docs/src/pages/api-reference/mdx-provider.mdx
+++ b/examples/docs/src/pages/api-reference/mdx-provider.mdx
@@ -7,7 +7,7 @@ title: MDXProvider
 ## Usage
 
 ```js
-import { MDXProvider } from '@mdx-js/tag';
+import { MDXProvider } from '@mdx-js/react';
 
 const MyH1 = props => <h1 style={{ color: 'tomato' }} {...props} />
 const MyParagraph = props => <p style={{ fontSize: '18px', lineHeight: 1.6 }} />

--- a/examples/docs/src/pages/guides/creating-interactive-code-blocks.mdx
+++ b/examples/docs/src/pages/guides/creating-interactive-code-blocks.mdx
@@ -8,7 +8,7 @@ custom `code` element to MDXProvider.
 ```javascript
 import React, {Component} from "react";
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from "react-live";
-import { MDXProvider } from '@mdx-js/tag'
+import { MDXProvider } from '@mdx-js/react'
 
 const MyCodeComponent = ({ children, ...props }) => (
   <LiveProvider code={children}>


### PR DESCRIPTION
```
import '@mdx-js/tag' // Doesn't work
import '@mdx-js/react' // Works

<MDXProvider components={p: props => <Paragraph {...props} />}>
    <MDXRenderer>{mdx.code.body}</MDXRenderer>
</MDXProvider>

I found the solution while browsing https://www.gatsbyjs.org/docs/mdx/customizing-components, which uses what I assume to be the correct import.

The issue caused some wasted time, so, if valid, do accept :) 

