### PR TITLE
Give more context in error message when parsing of MDX fails

### DIFF
--- a/packages/gatsby-mdx/gatsby/on-create-node.js
+++ b/packages/gatsby-mdx/gatsby/on-create-node.js
@@ -52,7 +52,8 @@ module.exports = async (
   const mdxNode = await createMDXNode({
     id: createNodeId(`${node.id} >>> Mdx`),
     node,
-    content
+    content,
+    getNode
   });
 
   createNode(mdxNode);
@@ -125,15 +126,17 @@ class BabelPluginTransformRelativeImports {
       return {
         visitor: {
           StringLiteral({ node }) {
-            let split = node.value.split('!');
+            let split = node.value.split("!");
             const nodePath = split.pop();
-            const loaders = `${split.join('!')}${split.length > 0 ? '!' : ''}`;
+            const loaders = `${split.join("!")}${split.length > 0 ? "!" : ""}`;
             if (nodePath.startsWith(".")) {
               const valueAbsPath = path.resolve(parentFilepath, nodePath);
-              const replacementPath = loaders + path.relative(
-                path.join(cache.directory, MDX_SCOPES_LOCATION),
-                valueAbsPath
-              );
+              const replacementPath =
+                loaders +
+                path.relative(
+                  path.join(cache.directory, MDX_SCOPES_LOCATION),
+                  valueAbsPath
+                );
               node.value = replacementPath;
             }
           }

--- a/packages/gatsby-mdx/utils/create-mdx-node.js
+++ b/packages/gatsby-mdx/utils/create-mdx-node.js
@@ -2,13 +2,33 @@ const crypto = require("crypto");
 const mdx = require("../utils/mdx");
 const extractExports = require("../utils/extract-exports");
 
-module.exports = async ({ id, node, content }) => {
-  let code
+module.exports = async ({ id, node, content, getNode }) => {
+  let code;
   try {
     code = await mdx(content);
-  } catch(e) {
-    // add the path of the file to simplify debugging error messages
-    e.message += `${node.absolutePath}: ${e.message}`;
+  } catch (e) {
+    // add location information of the node to simplify debugging error messages
+
+    // Files have the information assigned to itself, other sources most likely at the parent
+    const parent = getNode(node.parent) || {};
+    const absolutePath = node.absolutePath || parent.absolutePath;
+    const node_locale = node.node_locale || parent.node_locale;
+    const contentful_id = node.contentful_id || parent.contentful_id;
+    const title = node.title || parent.title;
+    const slug = node.slug || parent.slug;
+
+    const mdxLocation = [
+      `Gatsby: ${id}`,
+      absolutePath && `Path: ${absolutePath}`,
+      node_locale && `Locale: ${node_locale}`,
+      title && `Title: ${title}`,
+      slug && `Slug: ${slug}`,
+      contentful_id && `Contentful: ${contentful_id}`
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    e.message += `\nUnable to parse MDX at \n${mdxLocation}\n\n\n${e.message}`;
     throw e;
   }
 


### PR DESCRIPTION
The current code works fine when you serve your MDX from files.

This was great for the beginning, but we moved the data now into Contentful. The error messages now are pretty useless to my editors, hence the MDX node does not have a `absolutePath`, resulting in an useless:

```
  SyntaxError: unknown: Unterminated JSX contents (38:16)
    36 | </Downloads>
    37 | </GridWrapper>
  > 38 |     </MDXLayout>
       |                 ^
    39 |   )
    40 | }
    41 | MDXContent.isMDXComponent = true
```

There is no way to find out where this is coming from, except you know by any chance which pages contain `</Downloads>`.

This PR will add more information to the error message, as long it is available.

Supporting other sources next to filesystem and contentful should be super easy to implement.

The new output when somebody forgot a closing tag:

```
Unable to parse MDX at
  Gatsby: 6ab56d0e-6e13-5e8c-927a-80e2a6be41dc
  Locale: de
  Title: Presse
  Contentful: 3k9IUwbi3LLEZmzlO5bMWe
  Slug: presse
  unknown: Unterminated JSX contents (38:16)
    36 | </Downloads>
    37 | </GridWrapper>
  > 38 |     </MDXLayout>
       |                 ^
    39 |   )
    40 | }
    41 | MDXContent.isMDXComponent = true
```

This is released as:

```
@axe312/gatsby-mdx@0.7.0
```

Happy debugging :trollface: 